### PR TITLE
AACT-180:  OutcomeMeasuredValue was not being linked to the correct R…

### DIFF
--- a/app/models/outcome_measured_value.rb
+++ b/app/models/outcome_measured_value.rb
@@ -79,4 +79,8 @@ class OutcomeMeasuredValue < StudyRelationship
     }
   end
 
+  def gid
+    opts[:ctgov_group_code]
+  end
+
 end

--- a/spec/models/outcome_measured_value_spec.rb
+++ b/spec/models/outcome_measured_value_spec.rb
@@ -2,7 +2,18 @@ require 'rails_helper'
 
 describe OutcomeMeasuredValue do
   it "should belong to study as expected" do
+    nct_id='NCT02389088'
+    xml=Nokogiri::XML(File.read("spec/support/xml_data/#{nct_id}.xml"))
+    study=Study.new({xml: xml, nct_id: nct_id}).create
+    outcome=(study.outcomes.select{|o|o.outcome_type=='Primary' and o.title=='LH and FSH During Phase I and Phase II'}).first
+    expect(outcome.outcome_measured_values.size).to eq(30)
+    fsh=outcome.outcome_measured_values.select{|x|x.category=='FSH'}
+    expect(fsh.size).to eq(10)
+    o1=fsh.select{|x|x.ctgov_group_code=='O10'}.first
+    expect(o1.result_group.ctgov_group_code).to eq(o1.ctgov_group_code)
+  end
 
+  it "should belong to study as expected" do
     nct_id='NCT00023673'
     xml=Nokogiri::XML(File.read("spec/support/xml_data/#{nct_id}.xml"))
     study=Study.new({xml: xml, nct_id: nct_id}).create
@@ -91,6 +102,11 @@ describe OutcomeMeasuredValue do
     expect(om.dispersion_value).to eq(nil)
     expect(om.dispersion_value_num).to eq(nil)
     expect(om.explanation_of_na).to eq('Stimulated value not measured.')
+    om=study.outcome_measured_values.select{|x|x.title=='Estradiol During Phase I and Phase II'}
+    expect(om.size).to eq(10)
+    om1=om.select{|x|x.ctgov_group_code=='O1'}.first
+    expect(om1.dispersion_value).to eq('131')
+    expect(om1.param_value).to eq('451.7')
   end
 
 end


### PR DESCRIPTION
OutcomeMeasuredValue was not being linked to the correct ResultGroup.  It needs the method 'gid' to return it's ctgov_group_code in order to know which group to link to.

(Couldn't figure how to change the PR pull-to from master to development on the previous PR, so just closed it and recreated here on correct repo)