### PR TITLE
AACT-214:  The one-to-one related data should always be included when…

### DIFF
--- a/app/serializers/study_serializer.rb
+++ b/app/serializers/study_serializer.rb
@@ -33,47 +33,47 @@ class StudySerializer < ActiveModel::Serializer
             :official_title,
             :biospec_description,
             :created_at,
-            :updated_at,
-            :brief_summary,
-            :design,
-            :detailed_description,
-            :participant_flow,
-            :eligibility,
-            :facilities,
-            :outcomes,
-            :sponsors
+            :updated_at
 
   def attributes
-    super.merge(other_attributes)
+    super.merge(one_to_one_relationships).merge(other_attributes)
+  end
+
+  def one_to_one_relationships
+    {
+      brief_summary:        object.brief_summary.try(:attributes),
+      design:               object.design.try(:attributes),
+      detailed_description: object.detailed_description.try(:attributes),
+      eligibility:          object.eligibility.try(:attributes),
+      participant_flow:     object.participant_flow.try(:attributes),
+    }
   end
 
   def other_attributes
     if object.with_related_records
       {
-        brief_summary: object.brief_summary.attributes,
-        design: object.design.attributes,
-        detailed_description: object.detailed_description.attributes,
-        eligibility: object.eligibility.attributes,
-        participant_flow: object.participant_flow.attributes,
+       :facilities => serialized_facilities,
+       :outcomes   => serialized_outcomes,
+       :sponsors   => serialized_sponsors
       }
     else
       {}
     end
   end
 
-  def facilities
+  def serialized_facilities
     object.facilities.map {|f|
       FacilitySerializer.new(f,scope: scope, root: false, study: object)
     }
   end
 
-  def outcomes
+  def serialized_outcomes
     object.outcomes.map {|f|
       OutcomeSerializer.new(f,scope: scope, root: false, study: object)
     }
   end
 
-  def sponsors
+  def serialized_sponsors
     object.sponsors.map {|f|
       SponsorSerializer.new(f,scope: scope, root: false, study: object)
     }

--- a/spec/requests/studies_api_spec.rb
+++ b/spec/requests/studies_api_spec.rb
@@ -47,7 +47,7 @@ describe AACT2::V1::StudiesAPI do
             expect(returned_study_info).to be_a Hash
             expect(returned_study_info).to have_key('study')
             expect(response.body).to include(StudySerializer.new(study).to_json)
-            
+
           end
         end
 

--- a/spec/support/xml_data/NCT02903849.xml
+++ b/spec/support/xml_data/NCT02903849.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clinical_study>
+  <!-- This xml conforms to an XML Schema at:
+    https://clinicaltrials.gov/ct2/html/images/info/public.xsd
+ and an XML DTD at:
+    https://clinicaltrials.gov/ct2/html/images/info/public.dtd -->
+  <required_header>
+    <download_date>ClinicalTrials.gov processed this data on September 22, 2016</download_date>
+    <link_text>Link to the current ClinicalTrials.gov record.</link_text>
+    <url>https://clinicaltrials.gov/show/NCT02903849</url>
+  </required_header>
+  <id_info>
+    <org_study_id>2016080382</org_study_id>
+    <nct_id>NCT02903849</nct_id>
+  </id_info>
+  <brief_title>Using Self-Motivating Messages to Encourage People to Exercise More</brief_title>
+  <official_title>Using Self-Motivating Messages to Encourage People to Exercise More</official_title>
+  <sponsors>
+    <lead_sponsor>
+      <agency>Washington University School of Medicine</agency>
+      <agency_class>Other</agency_class>
+    </lead_sponsor>
+    <collaborator>
+      <agency>University of California, Los Angeles</agency>
+      <agency_class>Other</agency_class>
+    </collaborator>
+  </sponsors>
+  <source>Washington University School of Medicine</source>
+  <oversight_info>
+    <authority>United States: Institutional Review Board</authority>
+  </oversight_info>
+  <brief_summary>
+    <textblock>
+      The investigators are interested in using personalized, self-motivating messages to motivate
+      people to exercise more.
+    </textblock>
+  </brief_summary>
+  <detailed_description>
+    <textblock>
+      The investigators are interested in using personalized, self-motivating messages to motivate
+      people to exercise more. Through a partnership with a university, the investigators are
+      running a large-scale, randomized field controlled trial aimed at increasing exercise
+      frequencies during a 100-day challenge. The primary purpose of this study is to test whether
+      sending people motivating messages they wrote to themselves in the past can keep them
+      engaged in the challenge and motivate them to exercise more frequently. One week into the
+      challenge, employees who have signed up for the challenge will receive an email inviting
+      them to participate in a short activity. Employees who click on the link will be directed to
+      a survey. Once they finish reading the first introductory page and click &quot;next&quot;, they will
+      be randomly assigned to one of two groups. In the control group, employees will be
+      encouraged to write down what they think will motivate them to walk more after 20, 50, and
+      90 days into the Challenge. These employees will receive standard reminders on the 20th,
+      50th, and 90th day of the challenge. In the treatment group, employees will be encouraged to
+      write down motivating messages that they will receive on the 20th, 50th, and 90th day of the
+      Challenge.
+
+      All employees who are exposed to either the control or the treatment condition will be
+      included in the analysis.
+
+      The investigators plan to explore moderators based on (a) employees' demographics (age,
+      gender, ethnicity, position), (b) employees' participation in previous challenges, and (c)
+      employees' health condition and fitness level prior to the challenge (such as how actively
+      they have been participating in other wellness activities, their health statistics).
+    </textblock>
+  </detailed_description>
+  <overall_status>Not yet recruiting</overall_status>
+  <start_date>September 2016</start_date>
+  <completion_date type="Anticipated">January 2017</completion_date>
+  <primary_completion_date type="Anticipated">December 2016</primary_completion_date>
+  <phase>N/A</phase>
+  <study_type>Interventional</study_type>
+  <study_design>Allocation: Randomized, Intervention Model: Parallel Assignment, Masking: Single Blind (Subject), Primary Purpose: Supportive Care</study_design>
+  <primary_outcome>
+    <measure>Activity Level</measure>
+    <time_frame>Through study completion, 100 days</time_frame>
+    <safety_issue>No</safety_issue>
+    <description>Number of steps taken each day, as recorded in participants' online portal.</description>
+  </primary_outcome>
+  <secondary_outcome>
+    <measure>Body Mass Index (BMI)</measure>
+    <time_frame>After the 100-day challenge ends</time_frame>
+    <safety_issue>No</safety_issue>
+    <description>Most recent BMI in pounds (weight) and inches (height) as entered by participant, an expected average of 2 months after study start. Obtaining the data is dependent on the ability to obtain the data from the online portal.</description>
+  </secondary_outcome>
+  <secondary_outcome>
+    <measure>Cholesterol</measure>
+    <time_frame>After the 100-day challenge ends</time_frame>
+    <safety_issue>No</safety_issue>
+    <description>Most recent total, low, and high cholesterol levels in mg/dl as entered by participant, an expected average of 2 months after study start. Obtaining the data is dependent on the ability to obtain the data from the online portal.</description>
+  </secondary_outcome>
+  <secondary_outcome>
+    <measure>Blood Pressure</measure>
+    <time_frame>After the 100-day challenge ends</time_frame>
+    <safety_issue>No</safety_issue>
+    <description>Most recent systolic and diastolic levels in mmHg as entered by participant, an expected average of 2 months after study start. Obtaining the data is dependent on the ability to obtain the data from the online portal.</description>
+  </secondary_outcome>
+  <secondary_outcome>
+    <measure>Stress</measure>
+    <time_frame>After the 100-day challenge ends</time_frame>
+    <safety_issue>No</safety_issue>
+    <description>Most recent self-reported stress level on a 1-5 scale (with 1 indicating &quot;Relaxed&quot; and 5 indicating &quot;Highly Stressed&quot;) as entered by participant, an expected average of 2 months after study start. Obtaining the data is dependent on the ability to obtain the data from the online portal.</description>
+  </secondary_outcome>
+  <number_of_arms>2</number_of_arms>
+  <enrollment type="Anticipated">300</enrollment>
+  <condition>Physical Activity</condition>
+  <arm_group>
+    <arm_group_label>Control</arm_group_label>
+    <arm_group_type>Experimental</arm_group_type>
+    <description>On the 20th, 50th, and 90th day of the Challenge, Wellness Connection will email employees who participate in this survey. Employees will receive standard reminders generated by Wellness Connection.</description>
+  </arm_group>
+  <arm_group>
+    <arm_group_label>Treatment</arm_group_label>
+    <arm_group_type>Experimental</arm_group_type>
+    <description>On the 20th, 50th, and 90th day of the Challenge, Wellness Connection will email employees who participate in this survey. Employees will see the motivating messages they wrote at the beginning of the Challenge, in addition to Wellness Connection's standard reminders.</description>
+  </arm_group>
+  <intervention>
+    <intervention_type>Behavioral</intervention_type>
+    <intervention_name>Drafting Motivational Messages</intervention_name>
+    <description>Write down three motivating messages</description>
+    <arm_group_label>Control</arm_group_label>
+    <arm_group_label>Treatment</arm_group_label>
+  </intervention>
+  <intervention>
+    <intervention_type>Behavioral</intervention_type>
+    <intervention_name>Control Reminders</intervention_name>
+    <description>Receive standard reminders at three points during the challenge</description>
+    <arm_group_label>Control</arm_group_label>
+  </intervention>
+  <intervention>
+    <intervention_type>Behavioral</intervention_type>
+    <intervention_name>Treatment Reminders</intervention_name>
+    <description>Receive reminders containing the messages they leave themselves at three points during the challenge</description>
+    <arm_group_label>Treatment</arm_group_label>
+  </intervention>
+  <eligibility>
+    <criteria>
+      <textblock>
+        Inclusion Criteria:
+
+          -  Employees who click on the link inviting them to participate in an activity and are
+             assigned to either the treatment or control condition
+      </textblock>
+    </criteria>
+    <gender>Both</gender>
+    <minimum_age>18 Years</minimum_age>
+    <maximum_age>N/A</maximum_age>
+    <healthy_volunteers>Accepts Healthy Volunteers</healthy_volunteers>
+  </eligibility>
+  <overall_official>
+    <last_name>Hengchen Dai, Ph.D</last_name>
+    <role>Principal Investigator</role>
+    <affiliation>Washington University School of Medicine</affiliation>
+  </overall_official>
+  <overall_contact>
+    <last_name>Hengchen Dai, Ph.D</last_name>
+    <phone>3149354198</phone>
+    <email>hdai@wustl.edu</email>
+  </overall_contact>
+  <location>
+    <facility>
+      <name>Hengchen Dai</name>
+      <address>
+        <city>St. Louis</city>
+        <state>Missouri</state>
+        <zip>63108</zip>
+        <country>United States</country>
+      </address>
+    </facility>
+  </location>
+  <location_countries>
+    <country>United States</country>
+  </location_countries>
+  <verification_date>September 2016</verification_date>
+  <lastchanged_date>September 15, 2016</lastchanged_date>
+  <firstreceived_date>September 13, 2016</firstreceived_date>
+  <responsible_party>
+    <responsible_party_type>Principal Investigator</responsible_party_type>
+    <investigator_affiliation>Washington University School of Medicine</investigator_affiliation>
+    <investigator_full_name>Hengchen Dai</investigator_full_name>
+    <investigator_title>Assistant Professor of Organizational Behavior</investigator_title>
+  </responsible_party>
+  <is_fda_regulated>No</is_fda_regulated>
+  <has_expanded_access>No</has_expanded_access>
+  <!-- Results have not yet been posted for this study                                -->
+</clinical_study>


### PR DESCRIPTION
… retrieving a study via the API.  If user specifies 'with_related_records', then the one-to-many related data will be included