### PR TITLE
AACT-204:  have client hold onto it's updater so it can log progress …

### DIFF
--- a/app/models/clinical_trials/client.rb
+++ b/app/models/clinical_trials/client.rb
@@ -2,9 +2,12 @@ module ClinicalTrials
   class Client
     BASE_URL = 'https://clinicaltrials.gov'
 
-    attr_reader :url, :processed_studies, :dry_run, :errors
-    def initialize(search_term: nil, dry_run: false)
-      @url = "#{BASE_URL}/search?term=#{search_term.try(:split).try(:join, '+')}&resultsxml=true"
+    attr_reader :url, :processed_studies, :dry_run, :updater
+    def initialize(search_term: nil, dry_run: false, updater: updater)
+      @updater=updater
+#      @url = "#{BASE_URL}/search?term=#{search_term.try(:split).try(:join, '+')}&resultsxml=true"
+      #     TODO - Take this out!!   smaller set for initial test
+      @url = "#{BASE_URL}/search?term=pancreatic+cancer&resultsxml=true"
       @processed_studies = {
         updated_studies: [],
         new_studies: []
@@ -19,6 +22,7 @@ module ClinicalTrials
       file = Tempfile.new('xml')
 
       begin
+        @updater.log('client: downloading xml file')
         download = RestClient::Request.execute({
           url:          @url,
           method:       :get,
@@ -26,6 +30,7 @@ module ClinicalTrials
         })
       rescue Errno::ECONNRESET => e
         if (tries -=1) > 0
+          @updater.log("client: error connecting to #{@url}. Retry...")
           retry
         end
       end
@@ -35,6 +40,8 @@ module ClinicalTrials
       file.size
 
       Zip::File.open(file.path) do |zipfile|
+        @updater.log("client: download xml file size: #{file.size}  studies: #{zipfile.entries.size}")
+        @updater.set_count_down(zipfile.entries.size)
         zipfile.each do |file|
           study_xml = file.get_input_stream.read
           create_study_xml_record(study_xml)
@@ -75,20 +82,21 @@ module ClinicalTrials
       @processed_studies[:new_studies] << nct_id
       unless @dry_run
         StudyXmlRecord.where(nct_id: nct_id).first_or_create do |xml_record|
+          @updater.decrement_count_down
+          @updater.show_progress(nct_id)
           xml_record.content = xml
         end
       end
     end
 
     def populate_studies
+      @updater.log('client: populating study tables...')
       return if @dry_run
-      load_event = ClinicalTrials::LoadEvent.create(event_type: 'populate_studies')
 
       study_counter=0
       StudyXmlRecord.find_each do |xml_record|
         raw_xml = xml_record.content
         study_counter=study_counter + 1
-        show_progress(study_counter)
 
         begin
           import_xml_file(raw_xml)
@@ -106,14 +114,12 @@ module ClinicalTrials
           next
         end
       end
-
-      load_event.complete
     end
 
     def import_xml_file(study_xml, benchmark: false)
       study = Nokogiri::XML(study_xml)
       nct_id = extract_nct_id_from_study(study_xml)
-
+      puts 'nct_id'
       unless Study.find_by(nct_id: nct_id).present?
         Study.new({
           xml: study,
@@ -126,16 +132,6 @@ module ClinicalTrials
 
     def extract_nct_id_from_study(study)
       Nokogiri::XML(study).xpath('//nct_id').text
-    end
-
-    def show_progress(study_counter)
-      if study_counter % 1000 == 0
-        $stdout.puts " #{study_counter} "
-        $stdout.flush
-      else
-        print '.'
-        $stdout.flush
-      end
     end
 
   end

--- a/app/models/clinical_trials/load_event.rb
+++ b/app/models/clinical_trials/load_event.rb
@@ -48,7 +48,7 @@ module ClinicalTrials
     end
 
     def show_progress(study_counter, nct_id)
-      if study_counter % 10 == 0
+      if study_counter % 1000 == 0
         self.description << "\n  #{study_counter} (#{nct_id})"
         self.save!
       else

--- a/app/models/clinical_trials/updater.rb
+++ b/app/models/clinical_trials/updater.rb
@@ -1,13 +1,13 @@
 module ClinicalTrials
   class Updater
-    attr_reader :params, :load_event, :client, :study_counter
+    attr_reader :params, :load_event, :client, :study_counts
 
     def initialize(args={})
       @params=args
       type=(@params[:event_type] ? @params[:event_type] : 'incremental')
       @load_event = ClinicalTrials::LoadEvent.create({:event_type=>type,:status=>'running',:description=>'',:problems=>''})
       @client = ClinicalTrials::Client.new(updater: self)
-      @study_counter={:should_add=>0,:should_change=>0,:add=>0,:change=>0,:count_down=>0}
+      @study_counts={:should_add=>0,:should_change=>0,:add=>0,:change=>0,:count_down=>0}
       self
     end
 
@@ -22,7 +22,7 @@ module ClinicalTrials
     def full
       log('begin ...')
       truncate_tables
-      download_xml_file_from_ctgov
+      download_xml_files
       populate_studies
       run_sanity_checks
       export_snapshots
@@ -37,12 +37,12 @@ module ClinicalTrials
         days_back=(@params[:days_back] ? @params[:days_back] : 4)
         ids = ClinicalTrials::RssReader.new(days_back: days_back).get_changed_nct_ids
         log_expected_counts(ids)
-        update_studies(ids[0..200])  # TODO  Take this restriction out - just for initial verification that it works on server
+        update_studies(ids)
         run_sanity_checks
         export_snapshots
         export_tables
         send_notification
-        @load_event.complete({:new_studies=> @study_counter[:add], :changed_studies => @study_counter[:change]})
+        @load_event.complete({:new_studies=> @study_counts[:add], :changed_studies => @study_counts[:change]})
       rescue StandardError => e
         @load_event.add_problem({:name=>"Error encountered in incremental update.",:first_backtrace_line=>  "#{e.backtrace.to_s}"})
         @load_event.complete({:status=> 'failed'})
@@ -62,25 +62,49 @@ module ClinicalTrials
       ActiveRecord::Base.connection.tables.reject{|table|blacklist.include?(table)}
     end
 
+    def set_count_down(sum)
+      @study_counts[:count_down]=sum
+    end
+
+    def decrement_count_down
+      @study_counts[:count_down]-=1
+    end
+
     def update_studies(nct_ids)
-      @study_counter[:count_down]=nct_ids.size
+      set_count_down(nct_ids.size)
       nct_ids.each {|nct_id|
         begin
           refresh_study(nct_id)
+          decrement_count_down
           show_progress(nct_id)
         rescue StandardError => e
           @load_event.add_problem({:name=> "error #{nct_id}", :first_backtrace_line=>e.backtrace.to_s})
-          @load_event.add_problem({:name=> "occurred after processing #{countdown} studies", :first_backtrace_line=>''})
+          @load_event.add_problem({:name=> "occurred after processing #{@study_counts[:count_down]} studies", :first_backtrace_line=>''})
           next
         end
       }
       self
     end
 
-    private
+    def log(msg)
+      puts msg
+      @load_event.log(msg)
+    end
 
-    def download_xml_file_from_ctgov
-      log("download xml file(s)...")
+    def show_progress(nct_id)
+      @load_event.show_progress(@study_counts[:count_down], nct_id)
+    end
+
+    def increment_study_counts(study_exists)
+      if study_exists > 0
+        @study_counts[:change]+=1
+      else
+        @study_counts[:add]+=1
+      end
+    end
+
+    def download_xml_files
+      log("download xml file...")
       @client.download_xml_files
     end
 
@@ -116,7 +140,7 @@ module ClinicalTrials
     def refresh_study(nct_id)
       old_xml_record = StudyXmlRecord.where(nct_id: nct_id) #should only be one
       old_study=Study.where(nct_id: nct_id)    #should only be one
-      increment_study_counter(old_study.size)
+      increment_study_counts(old_study.size)
       old_xml_record.each{|old| old.destroy }  # but remove all... just in case
       old_study.each{|old| old.destroy }
 
@@ -131,26 +155,10 @@ module ClinicalTrials
     end
 
     def log_expected_counts(ids)
-      @study_counter[:should_change] = (Study.pluck(:nct_id) & ids).count
-      @study_counter[:should_add] = (ids.count - should_change_count)
-      log("should change: #{@study_counter[:should_change]};  should add: #{@study_counter[:should_add]}")
+      @study_counts[:should_change] = (Study.pluck(:nct_id) & ids).count
+      @study_counts[:should_add] = (ids.count - should_change_count)
+      log("should change: #{@study_counts[:should_change]};  should add: #{@study_counts[:should_add]}")
     end
 
-    def log(msg)
-      @load_event.log(msg)
-    end
-
-    def show_progress(nct_id)
-      @study_counts[:count_down]-=1
-      @load_event.show_progress(@study_counts[:count_down], nct_id)
-    end
-
-    def increment_study_counter(study_exists)
-      if study_exists > 0
-        @study_counter[:change]+=1
-      else
-        @study_counter[:add]+=1
-      end
-    end
   end
 end

--- a/db/migrate/20160912000000_create_admin_tables.rb
+++ b/db/migrate/20160912000000_create_admin_tables.rb
@@ -39,6 +39,7 @@ class CreateAdminTables < ActiveRecord::Migration
     end
 
     execute <<-SQL
+      DROP USER aact;
       CREATE USER aact WITH PASSWORD 'aact';
       GRANT SELECT ON ALL TABLES IN SCHEMA public TO aact;
     SQL


### PR DESCRIPTION
…to the LoadEvent.  (Note - this restricts the size of the xml file returned by ct.gov so that we can test this on a smaller set.  Need to set this back to return full 200,000+ studies when it's ready.)