### PR TITLE
unzipping the snapshot file when downloaded from heroku…  gunzip does…

### DIFF
--- a/app/models/clinical_trials/file_manager.rb
+++ b/app/models/clinical_trials/file_manager.rb
@@ -94,7 +94,7 @@ module ClinicalTrials
       schema_diagram_file=get_reg_file({:directory_name=>'documentation',:file_name=>'aact_schema.png'})
       data_dictionary_file=get_reg_file({:directory_name=>'documentation',:file_name=>'aact_data_definitions.xlsx'})
 
-      zip_file_name="#{Time.now.strftime('%Y%m%d')}_clinical_trials.gz"
+      zip_file_name="#{Time.now.strftime('%Y%m%d')}_clinical_trials.zip"
       File.delete(zip_file_name) if File.exist?(zip_file_name)
       Zip::File.open(zip_file_name, Zip::File::CREATE) {|zipfile|
         zipfile.add('data_dictionary.xlsx',data_dictionary_file)

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -53,11 +53,11 @@
     <p class='CodeRay'>
       <pre>
         <p class='code'>
-          <span class='command-prompt'>-&gt; </span><span class='command-entry'> gunzip <i>~/Downloads/YYYYMMDD_clinical_trials.gz </i></span>
+          <span class='command-prompt'>-&gt; </span><span class='command-entry'> unzip <i>~/Downloads/YYYYMMDD_clinical_trials.zip </i></span>
         </p>
       </pre>
     </p>
-    <p>This will unpack the 3 files contained in the zip package and save them to a directory named <i>YYYYMMDD_clinical_trials</i>. This directory will contain 3 files:</p>
+    <p>This will unpack the 3 files contained in the zip package and save them to the directory where the zip file exists. This directory will contain 3 files:</p>
   </ul>
     <ul class='regularDisplay'>
       <li><i>postgres_data.dmp</i> Postgres dump file containing all the instructions and data required to create a local copy of the AACT database.</li>
@@ -72,7 +72,7 @@
     <p class='CodeRay'>
       <pre>
         <p class='code'>
-          <span class='command-prompt'>-&gt; </span><span class='command-entry'> pg_restore -e -v -O -x --dbname=postgres</i> --no-owner --clean --create  <i>~/Downloads/YYYYMMDD_clinical_trials/postgres_data.dmp</i></span>
+          <span class='command-prompt'>-&gt; </span><span class='command-entry'> pg_restore -e -v -O -x --dbname=postgres</i> --no-owner --clean --create  <i>~/Downloads/postgres_data.dmp</i></span>
         </p>
       </pre>
     </p>


### PR DESCRIPTION
…n’t work - need to use unzip and seems the extension needs to be .zip, not .gz.  Also, when you unpack the zip file, it puts the files in the current directory, doesn’t create a subdirectory named for the zip file.  Update file naming and instructions.