### PR TITLE
Add feature to allow multiple load jobs to run simultaneously.  (Curr…

### DIFF
--- a/app/models/clinical_trials/client.rb
+++ b/app/models/clinical_trials/client.rb
@@ -62,11 +62,11 @@ module ClinicalTrials
       StudyXmlRecord.where(nct_id: nct_id).first_or_create {|rec|rec.content = xml} unless @dry_run
     end
 
-    def populate_studies
+    def populate_studies(study_filter=nil)
       return if @dry_run
       load_event = ClinicalTrials::LoadEvent.create( event_type: 'populate_studies')
 
-      studies_to_load=StudyXmlRecord.not_yet_loaded
+      studies_to_load=StudyXmlRecord.not_yet_loaded(study_filter)
       cntr=studies_to_load.size
       puts "will load #{cntr} studies..."
       studies_to_load.each do |xml_record|

--- a/app/models/study_xml_record.rb
+++ b/app/models/study_xml_record.rb
@@ -1,8 +1,12 @@
 class StudyXmlRecord < ActiveRecord::Base
   belongs_to :study, foreign_key: "nct_id"
 
-  def self.not_yet_loaded
-    where('created_study_at is null')
+  def self.not_yet_loaded(study_filter=nil)
+    if study_filter
+      where('created_study_at is null and nct_id like ?',"%#{study_filter}")
+    else
+      where('created_study_at is null')
+    end
   end
 
 end

--- a/lib/tasks/full_import_finalize.rake
+++ b/lib/tasks/full_import_finalize.rake
@@ -1,0 +1,9 @@
+namespace :import do
+  namespace :full do
+    namespace :finalize do
+      task :run, [:force] => :environment do |t, args|
+        ClinicalTrials::Updater.new({:event_type=>'finalize'}).run
+      end
+    end
+  end
+end

--- a/lib/tasks/restart0_full_import.rake
+++ b/lib/tasks/restart0_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart0 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 0
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'0'}).run
+    end
+  end
+end

--- a/lib/tasks/restart1_full_import.rake
+++ b/lib/tasks/restart1_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart1 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 1
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'1'}).run
+    end
+  end
+end

--- a/lib/tasks/restart2_full_import.rake
+++ b/lib/tasks/restart2_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart2 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 2
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'2'}).run
+    end
+  end
+end

--- a/lib/tasks/restart3_full_import.rake
+++ b/lib/tasks/restart3_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart3 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 3
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'3'}).run
+    end
+  end
+end

--- a/lib/tasks/restart4_full_import.rake
+++ b/lib/tasks/restart4_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart4 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 4
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'4'}).run
+    end
+  end
+end

--- a/lib/tasks/restart5_full_import.rake
+++ b/lib/tasks/restart5_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart5 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 5
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'5'}).run
+    end
+  end
+end

--- a/lib/tasks/restart6_full_import.rake
+++ b/lib/tasks/restart6_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart6 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 6
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'6'}).run
+    end
+  end
+end

--- a/lib/tasks/restart7_full_import.rake
+++ b/lib/tasks/restart7_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart7 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 7
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'7'}).run
+    end
+  end
+end

--- a/lib/tasks/restart8_full_import.rake
+++ b/lib/tasks/restart8_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart8 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 8
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'8'}).run
+    end
+  end
+end

--- a/lib/tasks/restart9_full_import.rake
+++ b/lib/tasks/restart9_full_import.rake
@@ -1,0 +1,8 @@
+namespace :import do
+  namespace :restart9 do
+    task :run, [:force] => :environment do |t, params|
+      # Restart full load.  Load only studies with NCT IDs that end with 9
+      ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true,:study_filter=>'9'}).run
+    end
+  end
+end

--- a/lib/tasks/restart_full_import.rake
+++ b/lib/tasks/restart_full_import.rake
@@ -1,6 +1,7 @@
 namespace :import do
   namespace :restart do
     task :run, [:force] => :environment do |t, params|
+      # Restart full load - load all studies
       ClinicalTrials::Updater.new({:event_type=>'full', :restart=>true}).run
     end
   end


### PR DESCRIPTION
…ent load is taking days).  If user specifies a study filter (number), have the job only load studies with NCT IDs that end in that number