### PR TITLE
aact-249 Fix Updater method to populate calculated_values table after…

### DIFF
--- a/lib/tasks/calculated_values.rake
+++ b/lib/tasks/calculated_values.rake
@@ -1,8 +1,8 @@
-namespace :create_calculated_values do
-  task run: :environment do
+namespace :calculated_values do
+  task create: :environment do
     $stdout.puts "Creating calculated values..."
     $stdout.flush
-    Study.create_calculated_values
+    ClinicalTrials::Updater.new.create_calculated_values
   end
 end
 


### PR DESCRIPTION
… the full load completes.  Only create rows for studies that don’t already have one.  Provide a rake task also, so we can do this by hand as well.