### PR TITLE
aact-370:  Wrap incremental update in a transaction.  If it fails, it…

### DIFF
--- a/app/models/clinical_trials/updater.rb
+++ b/app/models/clinical_trials/updater.rb
@@ -205,13 +205,13 @@ module ClinicalTrials
       PublicAnnouncement.destroy_all
       public_announcement=PublicAnnouncement.new(:description=>"The live AACT database is temporarily unavailable because the daily update is running.")
       public_announcement.save!
-      revoke_db_privs
-      remove_indexes  # Index significantly slow the load process.
-      update_studies(added_ids)
-      update_studies(changed_ids)
-      add_indexes
-      CalculatedValue.populate
-      grant_db_privs
+      ActiveRecord::Base.transaction do
+        remove_indexes  # Index significantly slow the load process.
+        update_studies(added_ids)
+        update_studies(changed_ids)
+        add_indexes
+        CalculatedValue.populate
+      end
       public_announcement.destroy
       populate_admin_tables
       log_actual_counts


### PR DESCRIPTION
… rolls back the SQL transactions that deleted studies prior to loading new versions - thereby preventing loss of info if the loads subsequently fail.  It also eliminates the need to lock users out during the update since all changes are applied at once when the transaction completes.