### PR TITLE
aact-385: Reboot the database before launching the full load so that …

### DIFF
--- a/app/models/clinical_trials/client.rb
+++ b/app/models/clinical_trials/client.rb
@@ -14,6 +14,15 @@ module ClinicalTrials
       @errors = []
     end
 
+    def reboot_db
+      db_name=ENV['S3_BUCKET_NAME']
+      aws_client = Aws::RDS::Client.new(region: ENV['AWS_REGION'])
+      resp = aws_client.reboot_db_instance({
+          db_instance_identifier: db_name,
+          force_failover: false,
+      })
+    end
+
     def download_xml_files
       tries ||= 5
 

--- a/app/models/clinical_trials/updater.rb
+++ b/app/models/clinical_trials/updater.rb
@@ -32,8 +32,9 @@ module ClinicalTrials
     def full
       begin
         log('begin ...')
+        @client.reboot_db
         revoke_db_privs
-        public_announcement=PublicAnnouncement.new(:description=>"The live AACT database is unavailable because full refresh is running. This may take several hours.  We apologize for the inconvenience.")
+        public_announcement=PublicAnnouncement.new(:description=>"The AACT database is currently unavailable because it is undergoing a full refresh. It should be available again by #{(Time.now + 15.hours).strftime("%I:%M%p  %m/%d/%Y")} We apologize for the inconvenience.")
         public_announcement.save!
         if should_restart?
           log("restarting full load...")


### PR DESCRIPTION
…it drops user connections which are currently causing the load to hang.