### PR TITLE
AACT-386:  Separate downloading of file from ctgov from populating th…

### DIFF
--- a/app/models/util/client.rb
+++ b/app/models/util/client.rb
@@ -34,7 +34,10 @@ module Util
       file.binmode
       file.write(download)
       file.size
+      file
+    end
 
+    def save_file_contents(file)
       Zip::File.open(file.path) do |zipfile|
         cnt=zipfile.size
         zipfile.each do |file|

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -59,7 +59,7 @@ module Util
     def retrieve_xml_from_ctgov
       log("retrieving xml from clinicaltrials.gov ...")
       AdminBase.connection.truncate('study_xml_records')
-      @client.download_xml_files
+      @client.save_file_contents(@client.download_xml_files)
     end
 
     def finalize_full_load

--- a/spec/models/util_client_spec.rb
+++ b/spec/models/util_client_spec.rb
@@ -59,7 +59,7 @@ describe Util::Client do
     end
   end
 
-  xdescribe '#download_xml_files' do
+  describe '#download_xml_files' do
     before do
       stub_request(:get, expected_url).
         with(:headers => stub_request_headers).
@@ -67,31 +67,18 @@ describe Util::Client do
     end
 
     context 'default dry_run false' do
-      it 'should create a study xml record and load event' do
-        expect {
-          subject.download_xml_files
-        }.to change{StudyXmlRecord.count}.by(2)
-
-        study_xml_record_1 = StudyXmlRecord.find_by(nct_id:'NCT00513591')
-        expect(study_xml_record_1).to be
+      it 'should save data from the xml file to the StudyXmlRecords table' do
+        StudyXmlRecord.destroy_all
+        subject.save_file_contents(File.open(Rails.root.join('spec','support','xml_data','download_xml_files.zip')))
+        expect(StudyXmlRecord.count).to eq(2)
+        rec = StudyXmlRecord.find_by(nct_id:'NCT00513591')
 
         raw_xml_content = Nokogiri::XML(raw_study_xml_1).child.to_xml
-        existing_xml_content = Nokogiri::XML(study_xml_record_1.content).child.to_xml
-        #expect(existing_xml_content).to eq(raw_xml_content)
+        existing_xml_content = Nokogiri::XML(rec.content).child.to_xml
+        #expect(existing_xml_content).to eq(raw_xml_content)  #tags don't always appear in expected order
       end
     end
 
-    context 'dry_run true' do
-      subject { described_class.new(search_term: search_term, dry_run: true) }
-
-      it 'should not create a study xml records or load events' do
-        expect {
-          expect {
-            subject.download_xml_files
-          }.not_to change{StudyXmlRecord.count}
-        }.not_to change{LoadEvent.count}
-      end
-    end
   end
 
   describe '#create_study_xml_record(nct_id,xml)' do


### PR DESCRIPTION
…e StudyXmlRecords table, so if we spend 40 minutes downloading and something causes table population to fail, we don’t have to start completely over.