### PR TITLE
aact-394:  Have loads run against a database in the background (back_…

### DIFF
--- a/app/models/public_announcement.rb
+++ b/app/models/public_announcement.rb
@@ -2,7 +2,9 @@ class PublicAnnouncement < AdminBase
 
   def self.populate(string)
     self.destroy_all
-    new(:description=>string).save!
+    announcement=new(:description=>string)
+    announcement.save!
+    announcement
   end
 
 end

--- a/app/models/util/file_manager.rb
+++ b/app/models/util/file_manager.rb
@@ -123,11 +123,12 @@ module Util
     end
 
     def dump_database
+      db_name=ActiveRecord::Base.connection.current_database
       dump_file_name=self.class.pg_dump_file
       File.delete(dump_file_name) if File.exist?(dump_file_name)
-
-      `PGPASSWORD=$DB_SUPER_PASSWORD pg_dump aact -h $DB_HOSTNAME -p 5432 -U $DB_SUPER_USERNAME --no-password --clean --exclude-table schema_migrations  -c -C -Fc -f  /var/local/share/tmp/postgres.dmp`
-
+      cmd="pg_dump #{db_name} -v -h localhost -p 5432 -U #{ENV['DB_SUPER_USERNAME']} --no-password --clean --exclude-table schema_migrations  -c -C -Fc -f  #{dump_file_name}"
+      puts cmd
+      system cmd
       return dump_file_name
     end
 
@@ -141,6 +142,12 @@ module Util
         }
       }
       return File.open(return_file)
+    end
+
+    def restore_public_db(static_file)
+      cmd="pg_restore -c -j 5 -v -h localhost -p 5432 -U #{ENV['DB_SUPER_USERNAME']}  -d aact #{static_file}"
+      puts cmd
+      system cmd
     end
 
     def take_snapshot

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,31 +1,20 @@
 development: &default
   adapter: postgresql
-  database: aact
+  database: back_aact
   encoding: utf8
   min_messages: warning
-  pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
-  reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
   timeout: 5000
 
 test:
   <<: *default
-  database: aact_test
+  database: back_aact_test
 
 production: &deploy
+  adapter: postgresql
+  database: back_aact
   encoding: utf8
   min_messages: warning
-  pool: <%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
-  url:  <%= ENV.fetch("DATABASE_URL", "") %>
 
 staging: *deploy
 
-docker: &docker
-  <<: *default
-  username: aact
-  password: abc123
-  host: postgres.db.host
-
-docker_test:
-  <<: *docker
-  database: aact_test

--- a/config/database_admin.yml
+++ b/config/database_admin.yml
@@ -3,8 +3,6 @@ development: &default
   database: aact_admin
   encoding: utf8
   min_messages: warning
-  pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
-  reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
   timeout: 5000
 
 test:
@@ -14,18 +12,7 @@ test:
 production: &deploy
   encoding: utf8
   min_messages: warning
-  pool: <%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
-  url:  <%= ENV.fetch("ADMIN_DATABASE_URL", "") %>
 
 staging: *deploy
 
-docker: &docker
-  <<: *default
-  username: aact
-  password: abc123
-  host: postgres.db.host
-
-docker_test:
-  <<: *docker
-  database: aact_admin_test


### PR DESCRIPTION
…aact) - then dump and restore it to the public database (aact) if sanity checks suggest all went well