### PR TITLE
aact-437: In Safari browser, user edit page displays email in last na…

### DIFF
--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -18,12 +18,6 @@
     <%= f.text_field :last_name, class: "form-control" %>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div class="form-group">
-      Currently waiting confirmation for: <%= resource.unconfirmed_email %>
-    </div>
-  <% end %>
-
   <div class="form-group">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>
     <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
@@ -45,5 +39,4 @@
 
 <% end %>
 <span class='floatRight'><%= button_to "Remove my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></span>
-
-<h4>  </h4>
+<h2 class='spacing hack'></h2>


### PR DESCRIPTION
…me field. Removing this superfluous code seems to fix it, but the field still is oddly highlighted - only in safari.  Other browsers are fine.