### PR TITLE
aact-488:  Github reports a serious security issue with the version o…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem "uglifier"
 gem "jbuilder"
 gem "rails-erd"
 gem 'rest-client'
-gem 'rubyzip'
 gem 'enumerize'
 gem 'bulk_insert'
 gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,7 +401,6 @@ DEPENDENCIES
   rest-client
   roo (~> 2.4.0)
   rspec-rails
-  rubyzip
   sass-rails
   shoulda-matchers
   sidekiq


### PR DESCRIPTION
…f rubyzip we were using.  I removed it and Roo installs the version it depends on: 1.2.1.  All tests successfully run, so assume this is ok.  Will check it in and see if we still get github warning.