### PR TITLE
Add execs and therubyracer to Gemfile in effort to prevent: Gem Load …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'font-awesome-sass'
 gem 'roo', '~> 2.4.0'
 gem 'string-similarity'
 gem 'gon'
+gem 'execjs'
+gem 'therubyracer', :platforms => :ruby
 
 # user registration
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ DEPENDENCIES
   devise
   devise-encryptable
   enumerize
+  execjs
   factory_girl_rails
   faraday
   faraday_middleware-aws-signers-v4


### PR DESCRIPTION
…Error is: Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.