### PR TITLE
Process getting killed when StudyXmlRecord.not_yet_loaded runs (assum…

### DIFF
--- a/app/models/util/client.rb
+++ b/app/models/util/client.rb
@@ -84,13 +84,15 @@ module Util
       cntr=total_count
       while cntr > 0
         #  Memory limitation: process in chunks. Too slow if we go one-by-one tho.
-        StudyXmlRecord.not_yet_loaded[0..10000].each do |xml_record|
+        StudyXmlRecord.find_each do |xml_record|
           stime=Time.now
-          import_xml_file(xml_record.content)
-          xml_record.created_study_at=Date.today
-          xml_record.save!
-          puts "#{cntr} saved #{xml_record.nct_id}:  #{Time.now - stime}"
-          cntr=cntr-1
+          if xml_record.created_study_at.blank?
+            import_xml_file(xml_record.content)
+            xml_record.created_study_at=Date.today
+            xml_record.save!
+            puts "#{cntr} saved #{xml_record.nct_id}:  #{Time.now - stime}"
+            cntr=cntr-1
+          end
         end
         cntr=StudyXmlRecord.not_yet_loaded.count
       end


### PR DESCRIPTION
…e it’s running out of memory).  Use StudyXmlRecord.find_each instead.  Then check that the created_study_at is blank before creating a study from it.  This will significantly slow the load process, but lets give it a try to see how long it takes.  Now that the app and db are on the same server, it might not be as bad