### PR TITLE
aact-457:  Get capistrano deployments working on Duke servers.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,7 +4,7 @@ require "capistrano/setup"
 # Include default deployment tasks
 require "capistrano/deploy"
 require 'capistrano/rails'
-require 'capistrano/chruby'
+#require 'capistrano/chruby'
 
 # Load the SCM plugin appropriate to your project:
 #

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'devise-encryptable'
 # deployment to server
 gem 'capistrano', '~> 3.8'
 gem 'capistrano-rails', '~> 1.2'
-gem 'capistrano-chruby'
 
 group :development do
   gem "quiet_assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,9 +92,6 @@ GEM
     capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-chruby (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.3)
     capistrano-rails (1.3.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -359,7 +356,6 @@ DEPENDENCIES
   bullet
   bundler-audit (>= 0.5.0)
   capistrano (~> 3.8)
-  capistrano-chruby
   capistrano-rails (~> 1.2)
   capybara-webkit
   coderay

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'single_test/tasks'
 
 Rails.application.load_tasks
 task(:default).clear

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,5 @@
 # config valid only for current version of Capistrano
 lock "3.8.2"
-set :chruby_ruby, 'ruby-2.4.0'
 
 set :application, "aact"
 set :repo_url, "git@github.com:ctti-clinicaltrials/aact.git"
@@ -10,7 +9,6 @@ ask :branch, 'development'
 set :rails_env, 'development'
 
 # Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, '/srv/web/aact-dev.oit.duke.edu'
 
 # Default value for :format is :airbrussh.
 #set :format, :airbrussh
@@ -31,10 +29,12 @@ set :format_options, command_output: true, log_file: "log/capistrano.log", color
 # Default value for default_env is {}
 
 set :default_env, {
-#  'PATH' => "/path/to/.rvm/ree-1.8.7-2009.10/bin:/path/to/.rvm/gems/ree/1.8.7/bin:/path/to/.rvm/bin:$PATH",
+  'PATH' => "/home/ctti-aact/bin/:/srv/web/aact.ctti-clinicaltrials.org/shared/bundle/ruby/2.4.0/bin:/opt/rh/rh-ruby24/root/usr/lib64:$PATH",
+  'LD_LIBRARY_PATH' => "/opt/rh/rh-ruby24/root/usr/lib64",
+  'APPLICATION_HOST' => ENV['APPLICATION_HOST'],
   'RUBY_VERSION' => 'ruby 2.4.0',
   'GEM_HOME' => '/home/ctti-aact/.gem/ruby',
-  'GEM_PATH' => '/home/ctti-aact/.gem/ruby:/opt/rh/rh-ruby24/root/usr/share/gems:/opt/rh/rh-ruby24/root/usr/local/share/gems'
+  'GEM_PATH' => '/home/ctti-aact/.gem/ruby/gems:/opt/rh/rh-ruby24/root/usr/share/gems:/opt/rh/rh-ruby24/root/usr/local/share/gems:/opt/rh/rh-ruby24/root/usr/lib64'
 }
 
 # Default value for keep_releases is 5

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -35,6 +35,7 @@
 #
 # Global options
 # --------------
+  set :deploy_to, '/srv/web/aact-dev.oit.duke.edu'
   set :ssh_options, {
     keys: %w(/home/ctti-aact/.ssh/id_rsa),
     forward_agent: false,
@@ -44,7 +45,7 @@
 # The server-based syntax can be used to override options:
 # ------------------------------------
  server "ctti-web-dev-01.oit.duke.edu",
-   roles: %w{web db app},
+   roles: %w{web app},
    ssh_options: {
      user: "ctti-aact", # overrides user setting above
      keys: %w(/home/ctti-aact/.ssh/id_rsa),

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -38,6 +38,7 @@
 # http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
 #
 # Global options
+  set :deploy_to, '/srv/web/aact.ctti-clinicaltrials.org'
   set :ssh_options, {
     keys: %w(/home/ctti-aact/.ssh/id_rsa),
     forward_agent: false,
@@ -46,8 +47,8 @@
 #
 # The server-based syntax can be used to override options:
 # ------------------------------------
- server "ctti-web-prod-01.oit.duke.edu",
-   roles: %w{web db app},
+ server "ctti-web-01.oit.duke.edu",
+   roles: %w{web app},
    ssh_options: {
      user: "ctti-aact", # overrides user setting above
      keys: %w(/home/ctti-aact/.ssh/id_rsa),


### PR DESCRIPTION
Disabled the rake db:migrations (by removing the db role) because our server name is ctti-aact but postgresql doesn’t allow hyphens in usernames, (db name is ctti).  This caused the deployment to fail.