### PR TITLE
production deployment trips up on the RSpec task (cuz RSpec::Core not…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,9 +8,12 @@ task(:default).clear
 task default: [:spec]
 
 if Rails.env != 'production'
-  task(:spec).clear
-  RSpec::Core::RakeTask.new(:spec) do |t|
-    t.verbose = false
+  begin
+    task(:spec).clear
+    RSpec::Core::RakeTask.new(:spec) do |t|
+      t.verbose = false
+    end
+  rescue
   end
 end
 


### PR DESCRIPTION
… loaded into prod). Just ignore the error