### PR TITLE
aact-528:  default Rails env to production.  Make sure RAILS_ENV is d…

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,2 +1,5 @@
 require File.expand_path('../application', __FILE__)
+# force Rails into production mode
+# We don't control web/app server & can't set it that way
+ENV['RAILS_ENV'] ||= 'production'
 Rails.application.initialize!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 ENV["RACK_ENV"] = "test"
+ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
 abort("AACT_ADMIN_DATABASE_URL environment variable is set")   if !ENV["AACT_ADMIN_DATABASE_URL"]


### PR DESCRIPTION
…efined in .bash_profile on all non-prod servers.  (This is the only way I know how to set this when we don’t have superuser privs on the server.)