### PR TITLE
aact-578:  run method not calling finalize_load.  All I can think is …

### DIFF
--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -27,13 +27,14 @@ module Util
         else
           incremental
         end
+        finalize_load
       rescue => error
         msg="#{error.message} (#{error.class} #{error.backtrace}"
         log("#{@load_event.event_type} load failed in run: #{msg}")
         load_event.add_problem(msg)
         load_event.complete({:status=>'failed', :study_counts=> study_counts})
+        finalize_load
       end
-      finalize_load
     end
 
     def db_mgr


### PR DESCRIPTION
…cuz it’s after the begin/rescue block. Moving it to get called within the block to see if this fixes the problem