### PR TITLE
aact-628:  use the migration hook:  at_exit to create the ctgov schem…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,30 @@ Rails.application.load_tasks
 task(:default).clear
 task default: [:spec]
 
+namespace :db do
+  def set_search_path
+    puts "Setting search path to ctgov..."
+    con=ActiveRecord::Base.connection
+    con.execute("create schema ctgov;")
+    con.execute("alter role ctti set search_path to ctgov;")
+    con.execute("grant usage on schema ctgov to ctti;")
+    con.execute("grant create on schema ctgov to ctti;")
+    con.reset!
+  end
+
+  task :before_set_search_path do
+    before { set_search_path }
+  end
+
+  task :after_set_search_path do
+    at_exit { set_search_path }
+  end
+
+end
+
+Rake::Task['db:create'].enhance(['db:after_set_search_path'])
+
+
 if Rails.env != 'production'
   begin
     task(:spec).clear


### PR DESCRIPTION
…a immediately after the database is created.