### PR TITLE
aact-655:  use postgres 9.6 to run pg_dumpall.  It is dumping data fr…

### DIFF
--- a/app/models/util/user_db_manager.rb
+++ b/app/models/util/user_db_manager.rb
@@ -72,7 +72,11 @@ module Util
       run_command_line(cmd)
 
       log "dumping User accounts..."
-      cmd="pg_dumpall -U  #{ENV['DB_SUPER_USERNAME']} -h #{public_host_name} --globals-only > #{account_file_name}"
+      # to backup user accounts on the public server, we need to use the same version of postgres (9.6) - but for some
+      # reason, we cannot get 9.2 replaced with 9.6 on the OIT servers, but can get a 9.6 instance installed,
+      # We should shift everything on OIT server to 9.6, but for now, just run the pg_dumpall using 9.6, cuz it won't work
+      # without it.
+      cmd="scl enable rh-postgresql96 bash; /opt/rh/rh-postgresql96/root/bin/pg_dumpall -U  #{ENV['DB_SUPER_USERNAME']} -h #{public_host_name} --globals-only > #{account_file_name}"
       run_command_line(cmd)
 
       event=Admin::UserEvent.new({:event_type=>'backup', :file_names=>" #{table_file_name}, #{event_file_name}, #{account_file_name}" })


### PR DESCRIPTION
…om db on DigitalOcean server which is at 9.6. The command won’t work unless the versions match.  We will upgrade everything to 9.6 on the OIT (processing) servers, but for now, just need pg_dumpall to work.