### PR TITLE
Rename columns in ctgov_beta (AACT 169 & 168)

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,13 +42,20 @@ namespace :db do
 
 
   task rename_columns: [:environment] do
-    find_columns = ActiveRecord::Base.connection.execute("SELECT information_schema.tables.table_schema, information_schema.tables.table_name, c.column_name
-                                                          FROM information_schema.tables
-                                                          INNER JOIN information_schema.columns c ON c.table_name = information_schema.tables.table_name
-                                                                                                  AND c.table_schema = information_schema.tables.table_schema
-                                                          WHERE c.column_name = 'ctgov_beta_group_code' AND information_schema.tables.table_schema= 'ctgov_beta' ;")
-    find_columns.each do |result|
-      ActiveRecord::Base.connection.execute("ALTER TABLE information_schema.tables.table_name RENAME COLUMN ctgov_beta_group_code TO ctgov_group_code;")
+
+    sql_one= "SELECT t.table_schema,
+                t.table_name,
+	              c.column_name
+          FROM information_schema.tables t
+          INNER JOIN information_schema.columns AS c on c.table_name = t.table_name
+                                AND c.table_schema = t.table_schema
+          WHERE c.column_name = 'ctgov_beta_group_code' AND t.table_schema= 'ctgov_beta'";
+
+    find_columns= ActiveRecord::Base.connection.execute(sql_one).to_a
+
+    find_columns.each do|r|
+      sql_two= "ALTER TABLE #{r['table_schema']}.#{r['table_name']} RENAME COLUMN ctgov_beta_group_code TO ctgov_group_code;"
+      ActiveRecord::Base.connection.execute(sql_two)
     end
   end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -40,6 +40,18 @@ namespace :db do
     con.execute("ALTER ROLE #{aact_superuser} IN DATABASE #{aact_back_db} SET SEARCH_PATH TO ctgov, support, public, ctgov_beta;")
   end
 
+
+  task rename_columns: [:environment] do
+    find_columns = ActiveRecord::Base.connection.execute("SELECT information_schema.tables.table_schema, information_schema.tables.table_name, c.column_name
+                                                          FROM information_schema.tables
+                                                          INNER JOIN information_schema.columns c ON c.table_name = information_schema.tables.table_name
+                                                                                                  AND c.table_schema = information_schema.tables.table_schema
+                                                          WHERE c.column_name = 'ctgov_beta_group_code' AND information_schema.tables.table_schema= 'ctgov_beta' ;")
+    find_columns.each do |result|
+      ActiveRecord::Base.connection.execute("ALTER TABLE information_schema.tables.table_name RENAME COLUMN ctgov_beta_group_code TO ctgov_group_code;")
+    end
+  end
+
   task copy_schema: [:environment] do
     aact_superuser = ENV['AACT_DB_SUPER_USERNAME'] || 'aact'
     if ENV['RAILS_ENV'] == 'test'


### PR DESCRIPTION
This PR allows User to run `rake db:rename_columns` which will analyses what tables in the **ctgov_beta schema** have the column `ctgov_beta_group_code` and renames that column to `ctgov_group_code`.

Found references in the code that use `ctgov_beta_group_code` and change them to `ctgov_group_code`.