### PR TITLE
Fixing airbrake development environment

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -15,7 +15,7 @@ Airbrake.configure do |c|
   # from the right sidebar.
   # https://github.com/airbrake/airbrake-ruby#project_id--project_key
   c.project_id = ENV['AIRBRAKE_PROJECT_ID']
-  c.project_key = ENV['AIRBRAKE_API_KEY']]
+  c.project_key = ENV['AIRBRAKE_API_KEY']
  
   
 
@@ -43,8 +43,8 @@ Airbrake.configure do |c|
   # unwanted environments such as :test.
   # NOTE: This option *does not* work if you don't set the 'environment' option.
   # https://github.com/airbrake/airbrake-ruby#ignore_environments
-  c.ignore_environments = %w[test]
-
+  c.ignore_environments = %w[development test]
+  
   # A list of parameters that should be filtered out of what is sent to
   # Airbrake. By default, all "password" attributes will have their contents
   # replaced.


### PR DESCRIPTION
- Line 15 had an extra bracket fixed the typo.
- Put in code to ignore development environment on line 46 in. 