### PR TITLE
hot-fix/AACT-266-fixes_for_the_loads

### DIFF
--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -75,9 +75,8 @@ class StudyJsonRecord < ActiveRecord::Base
   def self.full
     start_time = Time.current
     study_download = download_all_studies
-    Support::SupportBase.connection.execute('TRUNCATE TABLE study_json_records CASCADE')
-    nct_ids = Study.all.map(&:nct_id)
-    clear_out_data_for(nct_ids) unless nct_ids.blank?
+    nct_ids = StudyJsonRecord.all.map(&:nct_id)
+    clear_out_data_for(nct_ids)
 
     Zip::File.open(study_download.path) do |unzipped_folders|
       original_count = unzipped_folders.size

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -75,6 +75,7 @@ class StudyJsonRecord < ActiveRecord::Base
   def self.full
     start_time = Time.current
     study_download = download_all_studies
+    remove_indexes_and_constraints
     nct_ids = Study.all.pluck(:nct_id).uniq
     clear_out_data_for(nct_ids)
     StudyJsonRecord.destroy_all

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -85,10 +85,16 @@ class StudyJsonRecord < ActiveRecord::Base
       @count_down = original_count
       unzipped_folders.each do |file|
         begin
-        contents = file.get_input_stream.read
-        json = JSON.parse(contents)
-        study = json['FullStudy']
-        save_single_study(study)
+          if file.path ~= /Contents/
+            next
+          else
+            contents = file.get_input_stream.read
+            json = JSON.parse(contents)
+            study = json['FullStudy']
+            save_single_study(study)
+            @countdown -= 1
+            puts "#{@count_down} left to save"
+          end
         rescue Exception => error
           msg="#{error.message} (#{error.class} #{error.backtrace}"
           ErrorLog.error(msg)

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -75,8 +75,8 @@ class StudyJsonRecord < ActiveRecord::Base
   def self.full
     start_time = Time.current
     study_download = download_all_studies
-    remove_indexes_and_constraints
     nct_ids = Study.all.pluck(:nct_id).uniq
+    remove_indexes_and_constraints
     clear_out_data_for(nct_ids)
     StudyJsonRecord.destroy_all
 

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -76,8 +76,8 @@ class StudyJsonRecord < ActiveRecord::Base
     start_time = Time.current
     study_download = download_all_studies
     Support::SupportBase.connection.execute('TRUNCATE TABLE study_json_records CASCADE')
-    # nct_ids = StudyJsonRecord.all.map(&:nct_id)
-    # clear_out_data_for(nct_ids)
+    nct_ids = Study.all.map(&:nct_id)
+    clear_out_data_for(nct_ids) unless nct_ids.blank?
 
     Zip::File.open(study_download.path) do |unzipped_folders|
       original_count = unzipped_folders.size

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -95,6 +95,7 @@ class StudyJsonRecord < ActiveRecord::Base
         end  
       end
     end
+    add_indexes_and_constraints
   end
 
   def self.incremental

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -75,8 +75,9 @@ class StudyJsonRecord < ActiveRecord::Base
   def self.full
     start_time = Time.current
     study_download = download_all_studies
-    nct_ids = StudyJsonRecord.all.map(&:nct_id)
+    nct_ids = Study.all.pluck(:nct_id).uniq
     clear_out_data_for(nct_ids)
+    StudyJsonRecord.destroy_all
 
     Zip::File.open(study_download.path) do |unzipped_folders|
       original_count = unzipped_folders.size

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -1657,7 +1657,7 @@ class StudyJsonRecord < ActiveRecord::Base
   def save_with_result_group(group, name_of_model='BaselineMeasurement')
     return unless group
 
-    group.each{|i| i[:result_group_id] = @study_result_groups[i[:ctgov_group_code]][:id]}
+    group.each{|i| i[:result_group_id] = @study_result_groups.dig(i[:ctgov_group_code], :id)}
     name_of_model.safe_constantize.import(group, validate: false)
   end
 

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -75,8 +75,9 @@ class StudyJsonRecord < ActiveRecord::Base
   def self.full
     start_time = Time.current
     study_download = download_all_studies
-    nct_ids = StudyJsonRecord.all.map(&:nct_id)
-    clear_out_data_for(nct_ids)
+    Support::SupportBase.connection.execute('TRUNCATE TABLE study_json_records CASCADE')
+    # nct_ids = StudyJsonRecord.all.map(&:nct_id)
+    # clear_out_data_for(nct_ids)
 
     Zip::File.open(study_download.path) do |unzipped_folders|
       original_count = unzipped_folders.size

--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -85,9 +85,7 @@ class StudyJsonRecord < ActiveRecord::Base
       @count_down = original_count
       unzipped_folders.each do |file|
         begin
-          if file.path ~= /Contents/
-            next
-          else
+          unless file.path =~ /Contents/
             contents = file.get_input_stream.read
             json = JSON.parse(contents)
             study = json['FullStudy']

--- a/app/models/util/db_manager.rb
+++ b/app/models/util/db_manager.rb
@@ -49,6 +49,7 @@ module Util
     # 4. verify the study count (permissions are not granted again to prevent bad data from being used)
     # 5. grant connection permissions again
     def restore_database(schema_type, connection, filename)
+      schema = "ctgov"
       config = connection.instance_variable_get('@config')
       host, port, username, database, password = config[:host], config[:port], config[:username], config[:database], config[:password]
 

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -253,8 +253,6 @@ module Util
         log('begin full load ...')
         StudyJsonRecord.full
       end
-      truncate_tables unless should_restart?
-      remove_indexes_and_constraints # Index significantly slow the load process. Will be re-created after data loaded.
       study_counts[:should_add] = Support::StudyXmlRecord.not_yet_loaded.count
       study_counts[:should_change] = 0
       @client.populate_studies
@@ -298,6 +296,9 @@ module Util
       load_event.log('add indexes and constraints..')
       add_indexes_and_constraints if params[:event_type] == 'full'
 
+      load_event.log('execute data count verification...')
+      Verifier.refresh
+      
       load_event.log('execute study search...')
       days_back = (Date.today - Date.parse('2013-01-01')).to_i if load_event.event_type == 'full'
       StudySearch.execute(days_back)

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -303,11 +303,6 @@ module Util
     # 8. create flat files
     def finalize_load
       log('finalizing load...')
-
-      unless params[:event_type] == 'full'
-        load_event.log('execute study statistics verification...')
-        Verifier.refresh
-      end
       
       load_event.log('execute study search...')
       days_back = (Date.today - Date.parse('2013-01-01')).to_i if load_event.event_type == 'full'

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -270,6 +270,9 @@ module Util
     # 2. update calculated values
     # 3. run saved searches
     def incremental
+      log('storing study statistics data...')
+      verifier = Verifier.create(source: ClinicalTrialsApi.study_statistics.dig('StudyStatistics', "ElmtDefs", "Study"))
+          
       log('begin incremental load...')
 
       db_mgr.remove_constrains
@@ -277,6 +280,9 @@ module Util
       db_mgr.add_constraints
 
       log('end of incremental load method')
+      load_event.log('execute study statistics verification...')
+      verifier.verify('ctgov')
+      verifier.write_data_to_file('ctgov')
       true
     end
 

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -298,11 +298,10 @@ module Util
     def finalize_load
       log('finalizing load...')
 
-      load_event.log('add indexes and constraints..')
-      add_indexes_and_constraints if params[:event_type] == 'full'
-
-      load_event.log('execute study statistics verification...')
-      Verifier.refresh
+      unless params[:event_type] == 'full'
+        load_event.log('execute study statistics verification...')
+        Verifier.refresh
+      end
       
       load_event.log('execute study search...')
       days_back = (Date.today - Date.parse('2013-01-01')).to_i if load_event.event_type == 'full'
@@ -314,9 +313,6 @@ module Util
         load_event.log('set downcase mesh terms...')
         set_downcase_terms
       end
-
-      load_event.log('populate admin tables...')
-      # populate_admin_tables
 
       load_event.log('run sanity checks...')
       load_event.run_sanity_checks

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -248,7 +248,7 @@ module Util
 
     def full
         begin
-          log('storying study statistics data...')
+          log('storing study statistics data...')
           verifier = Verifier.create(source: ClinicalTrialsApi.study_statistics.dig('StudyStatistics', "ElmtDefs", "Study"))
           
           log('begin full load ...')
@@ -301,7 +301,7 @@ module Util
       load_event.log('add indexes and constraints..')
       add_indexes_and_constraints if params[:event_type] == 'full'
 
-      load_event.log('execute data count verification...')
+      load_event.log('execute study statistics verification...')
       Verifier.refresh
       
       load_event.log('execute study search...')

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -230,7 +230,7 @@ module Util
                  else
                    incremental
                  end
-        finalize_load if status != false
+        # finalize_load if status != false
       rescue StandardError => e
         begin
           msg = "#{e.message} (#{e.class} #{e.backtrace}"
@@ -254,15 +254,15 @@ module Util
           log('begin full load ...')
           StudyJsonRecord.full
 
-          load_event.log('execute study statistics verification...')
-          verifier.verify('ctgov')
-          verifier.write_data_to_file('ctgov')
+          # load_event.log('execute study statistics verification...')
+          # verifier.verify('ctgov')
+          # verifier.write_data_to_file('ctgov')
         rescue => error
           msg="#{error.message} (#{error.class} #{error.backtrace}"
           Airbrake.notify(error)
         end
-      MeshTerm.populate_from_file
-      MeshHeading.populate_from_file
+      # MeshTerm.populate_from_file
+      # MeshHeading.populate_from_file
     end
 
     # incremental steps


### PR DESCRIPTION
- set the code to clear out study_json_records when doing a full load
- added verifier refresh method call to finalize load method
- removed call to truncate tables after full load