### PR TITLE
hot-fix/AACT-265-blacklist_verifier_and_bug_fix_result_groups

### DIFF
--- a/app/models/study_json_record.rb
+++ b/app/models/study_json_record.rb
@@ -1648,7 +1648,9 @@ class StudyJsonRecord < ActiveRecord::Base
   def save_with_result_group(group, name_of_model='BaselineMeasurement')
     return unless group
 
-    group.each{|i| i[:result_group_id] = @study_result_groups[i[:ctgov_group_code]][:id]}
+    group.map do |i| 
+      i[:result_group_id] = @study_result_groups.dig(i[:ctgov_group_code], :id)
+    end
     name_of_model.safe_constantize.import(group, validate: false)
   end
 

--- a/app/models/util/db_manager.rb
+++ b/app/models/util/db_manager.rb
@@ -284,6 +284,7 @@ module Util
         study_json_records
         use_cases
         use_case_attachments
+        verifier
       )
       table_names=con.tables.reject{|table|blacklist.include?(table)}
     end


### PR DESCRIPTION
- made edits to the how the result_groups_id is found so that it won't throw errors
- added verifier to blacklist