### PR TITLE
Send out an email report about differences between clinicaltrials.gov and aact

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -14,10 +14,8 @@ class Notifier < ApplicationMailer
     mail(to: email_addr, subject: subject, from: 'ctti@duke.edu')
   end
 
-  def report_diff(email, link)
-    link = https://aact.ctti-clinicaltrials.org/static/differences/study_statistics/verifier_differences_ctgov.csv
-    
+  def report_diff(email)
     subj="Differences between ClinicalTrials.gov and AACT"
-    mail(to: email, subject: subj)
+    mail(to: email, subject: subj, from: 'ctti@duke.edu')
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -13,4 +13,11 @@ class Notifier < ApplicationMailer
     @schema = schema
     mail(to: email_addr, subject: subject, from: 'ctti@duke.edu')
   end
+
+  def report_diff(email, link)
+    link = https://aact.ctti-clinicaltrials.org/static/differences/study_statistics/verifier_differences_ctgov.csv
+    
+    subj="Differences between ClinicalTrials.gov and AACT"
+    mail(to: email, subject: subj)
+  end
 end

--- a/app/models/verifier.rb
+++ b/app/models/verifier.rb
@@ -31,6 +31,12 @@ class Verifier < ActiveRecord::Base
               ]
       end
     end
+    Verifier.alert_admins_about_differences
+  end
+
+  def self.alert_admins_about_differences
+    admin_emails = ENV.fetch("AACT_ADMIN_EMAILS", "").split(",")
+    admin_emails.each {|admin_email| Notifier.report_diff(admin_email).deliver_now}
   end
 
   def get_source_from_file(file_path="#{Util::FileManager.new.study_statistics_directory}/verifier_source_ctgov.json")

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,1 +1,5 @@
-<%= yield %>
+<html>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/notifier/report_diff.html.erb
+++ b/app/views/notifier/report_diff.html.erb
@@ -1,0 +1,1 @@
+<p> Here are the report differences between ClinicalTrials.gov and AACT. </p>

--- a/app/views/notifier/report_diff.html.erb
+++ b/app/views/notifier/report_diff.html.erb
@@ -1,1 +1,1 @@
-<p> Here are the report differences between ClinicalTrials.gov and AACT. </p>
+<a href='https://aact.ctti-clinicaltrials.org/static/differences/study_statistics/verifier_differences_ctgov.csv'>Here are the report differences between ClinicalTrials.gov and AACT.</a>


### PR DESCRIPTION
- Added a view stating differences 
- Create an action in Notifier with a link to the csv differences.