### PR TITLE
AACT-365 Remove RACK_TIMEOUT

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,6 @@ module AACT
     AACT_OWNER_EMAIL       = ENV['AACT_OWNER_EMAIL']                   # Don't define this if your email service is not setup
     AACT_ADMIN_EMAILS      = ENV['AACT_ADMIN_EMAILS'] || "aact@your-org.org,admin@your-org.org" # Identifes who will receive load notifications
     AACT_STATIC_FILE_DIR   = ENV['AACT_STATIC_FILE_DIR'] || '~/aact-files'  # directory containing AACT static files such as the downloadable db snapshots
-    RACK_TIMEOUT           = ENV['RACK_TIMEOUT'] || 10
 
     APPLICATION_HOST          = 'localhost'
     AACT_HOST = ENV['AACT_HOST'] || 'localhost'


### PR DESCRIPTION
In file config/application.rb, I deleted RACK_TIMEOUT because the rails server is not used in aact-core.