### PR TITLE
AACT-366 Remove APPLICATION_HOST from aact-core.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,6 @@ module AACT
     AACT_STATIC_FILE_DIR   = ENV['AACT_STATIC_FILE_DIR'] || '~/aact-files'  # directory containing AACT static files such as the downloadable db snapshots
     RACK_TIMEOUT           = ENV['RACK_TIMEOUT'] || 10
 
-    APPLICATION_HOST          = 'localhost'
     AACT_HOST = ENV['AACT_HOST'] || 'localhost'
     if Rails.env != 'test'
       AACT_PUBLIC_HOSTNAME      =  ENV['AACT_PUBLIC_HOSTNAME'] || 'localhost'#Server on which the publicly accessible database resides

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,7 +51,6 @@ set :format_options, command_output: true, log_file: "#{ENV.fetch('STATIC_FILE_D
 set :default_env, {
   'PATH' => ENV['AACT_PATH'] || "<server-path>/shared/bundle/ruby/2.4.5/bin:/opt/rh/rh-ruby24/root/usr/lib64",
   'LD_LIBRARY_PATH' => ENV['LD_LIBRARY_PATH'] || "/opt/rh/rh-ruby24/root/usr/lib64",
-  'APPLICATION_HOST' => ENV['APPLICATION_HOST'] || 'localhost',
   'AACT_STATIC_FILE_DIR' => ENV['AACT_STATIC_FILE_DIR'] || '~/aact-files',
   'RUBY_VERSION' =>  ENV['RUBY_VERSION'] || 'ruby 2.4.5',
   'GEM_HOME' => ENV['GEM_HOME'] || '~/.gem/ruby',


### PR DESCRIPTION
Deleted APPLICATION_HOST constant from application.rb and deploy.rb files.