### PR TITLE
AACT-364 Remove AACT_STATIC_FILE_DIR references

### DIFF
--- a/app/models/util/db_manager.rb
+++ b/app/models/util/db_manager.rb
@@ -41,7 +41,7 @@ module Util
       run_command_line(cmd)
 
       filename = File.basename(dump_file_location)
-      record = FileRecord.create(file_type: "snapshot", filename: filename ) 
+      record = FileRecord.create(file_type: "snapshot", filename: filename )
       record.file.attach(io: File.open(dump_file_location), filename: filename)
       record.update(url: record.file.service_url(filename: filename))
 
@@ -109,7 +109,7 @@ module Util
       restore_database(schema, public_connection, fm.pg_dump_file)
     end
 
-      
+
     def clear_out_data_for(nct_ids)
       ids=nct_ids.map { |i| "'" + i.to_s + "'" }.join(",")
       Util::DbManager.loadable_tables.each { |table|
@@ -427,7 +427,7 @@ module Util
     }
 
     END
-  
+
     File.write("./public/static/documentation/schema.dot", graph)
     `dot -Tpng ./public/static/documentation/schema.dot -o ./public/static/documentation/aact_schema.png`
     end
@@ -528,11 +528,6 @@ module Util
       AACT::Application::AACT_DB_SUPER_USERNAME
     end
 
-    def static_file_dir
-      AACT::Application::AACT_STATIC_FILE_DIR
-    end
-
-
     def public_connection
       db = @config[:public]
       return unless db
@@ -556,12 +551,12 @@ module Util
       restore_database('normal', ActiveRecord::Base.connection, path_to_file)
       puts 'done'
     end
-    
+
     def restore_from_url(params={})
       url = params[:url]
       database_name = params[:database_name] || 'aact'
       return unless url
-      
+
       tries ||= 5
       file_path = "#{Rails.root}/tmp/snapshots"
       FileUtils.rm_rf(file_path)
@@ -593,7 +588,7 @@ module Util
       puts 'done'
 
       restore_from_file({path_to_file: "#{file_path}/postgres_data.dmp", database: database_name})
-      
+
       print 'removing temp folder...'
       FileUtils.rm_rf(file_path)
       puts 'done'

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,6 @@ module AACT
     AACT_DB_SUPER_USERNAME = ENV['AACT_DB_SUPER_USERNAME'] || 'aact'   # Name of postgres superuser that has permission to create a database.
     AACT_OWNER_EMAIL       = ENV['AACT_OWNER_EMAIL']                   # Don't define this if your email service is not setup
     AACT_ADMIN_EMAILS      = ENV['AACT_ADMIN_EMAILS'] || "aact@your-org.org,admin@your-org.org" # Identifes who will receive load notifications
-    AACT_STATIC_FILE_DIR   = ENV['AACT_STATIC_FILE_DIR'] || '~/aact-files'  # directory containing AACT static files such as the downloadable db snapshots
     RACK_TIMEOUT           = ENV['RACK_TIMEOUT'] || 10
 
     APPLICATION_HOST          = 'localhost'


### PR DESCRIPTION
Removed AACT_STATIC_FILE_DIR references from other parts of the application. Deleted constant AACT_STATIC_FILE_DIR from application.rb and db_manager.rb files.