### PR TITLE
AACT-418: Add a rescue to the Util::Updater#execute method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "database_cleaner"
+  gem "database_cleaner", "1.8.5"
   gem "formulaic"
   gem "launchy"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,12 +124,7 @@ GEM
     crass (1.0.6)
     css_parser (1.11.0)
       addressable
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
+    database_cleaner (1.8.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -373,7 +368,7 @@ DEPENDENCIES
   caxlsx
   coderay
   colorize
-  database_cleaner
+  database_cleaner (= 1.8.5)
   enumerize
   execjs
   factory_bot_rails

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -117,9 +117,9 @@ module Util
       # send_notification
       
     rescue => e
-      # set the load event to error
-      @load_event.update({ status:'error'}) 
-      # set the problems attribute in the load event to the exception message
+      # set the load event status to "error"
+      @load_event.update({ status: 'error'}) 
+      # set the load event problems to the exception message
       @load_event.update({ problems: "#{e.message}\n\n#{e.backtrace.join("\n")}" }) 
     end
 

--- a/app/models/util/updater.rb
+++ b/app/models/util/updater.rb
@@ -109,12 +109,18 @@ module Util
       end
 
       # refresh_data_definitions
-
+      
       # 11. change the state of the load event from “running” to “complete”
       @load_event.update({ status:'complete'})
 
       # 12. send email
       # send_notification
+      
+    rescue => e
+      # set the load event to error
+      @load_event.update({ status:'error'}) 
+      # set the problems attribute in the load event to the exception message
+      @load_event.update({ problems: "#{e.message}\n\n#{e.backtrace.join("\n")}" }) 
     end
 
     def current_study_differences

--- a/spec/models/utils/util_updater_spec.rb
+++ b/spec/models/utils/util_updater_spec.rb
@@ -225,16 +225,14 @@ describe Util::Updater do
 
   end
 
-  # context 'when there is a failure/exception in the Util::Updater#execute method' do
-  #   it 'should set the load event to error, set the problems attribute in the load event to the exception message' do
-  #     updater=Util::Updater.new
-  #     updater.execute
-  #     allow(db_mgr.remove_constraints).to receive(:foo).and_raise("failed gracefully")
-  #     db_mgr.remove_constraints.foo
-  #     expect(updater.load_event.problems).to include("undefined method `foo' for #<Util::Updater")
-  #     expect(updater.load_event.problems.size).to  be > 100
-  #     expect(updater.load_event.status).to eq('error')
-  #   end
-  # end
+  context 'when there is a failure/exception in the Util::Updater#execute method' do
+    it 'should set the load event status to "error", and set problems to the exception message "test error"' do
+      updater=Util::Updater.new
+      allow(updater.db_mgr).to receive(:remove_constraints).and_raise('test error')
+      updater.execute
+      expect(updater.load_event.problems).to include('test error')
+      expect(updater.load_event.status).to eq('error')
+    end
+  end
 
 end

--- a/spec/models/utils/util_updater_spec.rb
+++ b/spec/models/utils/util_updater_spec.rb
@@ -225,4 +225,16 @@ describe Util::Updater do
 
   end
 
+  # context 'when there is a failure/exception in the Util::Updater#execute method' do
+  #   it 'should set the load event to error, set the problems attribute in the load event to the exception message' do
+  #     updater=Util::Updater.new
+  #     updater.execute
+  #     allow(db_mgr.remove_constraints).to receive(:foo).and_raise("failed gracefully")
+  #     db_mgr.remove_constraints.foo
+  #     expect(updater.load_event.problems).to include("undefined method `foo' for #<Util::Updater")
+  #     expect(updater.load_event.problems.size).to  be > 100
+  #     expect(updater.load_event.status).to eq('error')
+  #   end
+  # end
+
 end


### PR DESCRIPTION
- Added an exception rescue to the Util::Updater#execute method so that we can handle Load Events that fail.

- Simulated an exception on AACT core Util::Updater#execute and tested that the Load Event attribute `status:` was set to "error" and `problems:` was set to the exception message. 

<img width="1280" alt="Screen Shot 2022-10-12 at 9 49 29 AM" src="https://user-images.githubusercontent.com/81119399/195721903-40cc0500-c742-45f0-9147-ec26888e8391.png">
<img width="1280" alt="Screen Shot 2022-10-12 at 9 50 34 AM" src="https://user-images.githubusercontent.com/81119399/195721932-a04ae3c6-0688-4c0a-b69e-927c0bb64826.png">

- Both were verified in AACT admin Events index and show views.

<img width="1280" alt="Screen Shot 2022-10-12 at 11 29 10 AM" src="https://user-images.githubusercontent.com/81119399/195721968-67c99f0b-db1c-4896-af50-47bd5f1ef4db.png">
<img width="1280" alt="Screen Shot 2022-10-12 at 11 31 43 AM" src="https://user-images.githubusercontent.com/81119399/195721994-6f6a1288-7e50-4511-a321-0e1dbfd25c5f.png">

- Added a models Util::Updater#execute Spec test case to verify the functionality of the exception rescue.

<img width="1280" alt="Screen Shot 2022-10-13 at 2 52 50 PM" src="https://user-images.githubusercontent.com/81119399/195722863-94b0749d-d5b3-4774-b168-4f125c3e97cb.png">











