### PR TITLE
AACT-485: Format the table names in the schema image in snake_case

### DIFF
--- a/app/models/util/db_image_generator.rb
+++ b/app/models/util/db_image_generator.rb
@@ -19,9 +19,9 @@ module Util
     end
 
     def generate_edges
-      study_edges = StudyRelationship.study_models.map { |k| "#{k.name} -> Study" }.join("\n")
+      study_edges = StudyRelationship.study_models.map { |k| "#{k.name.tableize.pluralize}" }.join("\n")
       extra_edges = Util::DbManager.foreign_key_constraints.map do |k|
-        "#{k[:child_table].singularize.camelize} -> #{k[:parent_table].singularize.camelize}"
+        "#{k[:child_table].tableize.pluralize} -> #{k[:parent_table].tableize.pluralize}"
       end.join("\n")
       "#{study_edges}\n#{extra_edges}"
     end
@@ -34,9 +34,9 @@ module Util
     def table(model)
       attributes = model.columns_hash.map { |k, v| "<tr><td>#{k}</td><td>#{v.type}</td></tr>" }.join("\n")
       <<-DOT_CODE
-        #{model.name} [label=<
+        #{model.name.tableize.pluralize} [label=<
         <table border="0" cellborder="1" cellspacing="0">
-          <tr><td colspan="2"><b>#{model.name}</b></td></tr>
+          <tr><td colspan="2"><b>#{model.name.tableize.pluralize}</b></td></tr>
           #{attributes}
         </table>>];
       DOT_CODE

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -73,8 +73,8 @@ namespace :db do
     `pg_dump -U #{aact_superuser} --schema='ctgov' --schema-only #{aact_back_db} #{connection} | sed 's/ctgov/ctgov_beta/g; s/ctgov_beta_group_code/ctgov_group_code/g' | psql -U #{aact_superuser} -d #{aact_back_db} #{connection}`
   end
 
-  task generate_schema_png: [:environment] do
-    Util::DbManager.new.schema_image
+  task :generate_schema_png, [:file_name] => :environment do |t, args|
+    Util::DbImageGenerator.new.schema_image(args[:file_name])
   end
 
 


### PR DESCRIPTION
[Work for AACT-485](https://codethedream.atlassian.net/browse/AACT-485) 

## Refactored code to use the snake case title:

![somename14](https://user-images.githubusercontent.com/66342665/228597766-3e5a0b7f-cb96-434f-8e37-043060d925a2.png)
