### PR TITLE
AACT-489: Create a rake task for background jobs

### DIFF
--- a/lib/tasks/aact.rake
+++ b/lib/tasks/aact.rake
@@ -1,6 +1,15 @@
 include ActionView::Helpers::NumberHelper
 
 namespace :aact do
+  task :process_jobs, [] => :environment do
+    loop do
+      sleep 10
+      puts "checking for jobs to process"
+      job = BackgroundJob::DbQuery.where(status: :pending).order(created_at: :asc).first
+      job.process if job
+    end
+  end
+
   task :process, [] => :environment do
     updater = Util::Updater.new
     updater.start


### PR DESCRIPTION
- Created Background Jobs rake task to process jobs:

<img width="1280" alt="Screen Shot 2023-05-16 at 1 08 01 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/5624a927-3ff7-4d20-9556-d75fe2c50621">

- Background Jobs index page shows that Job ID: 335 has a status of "pending" and is "Queued":

<img width="1280" alt="Screen Shot 2023-05-15 at 11 22 36 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/f2f23267-c55f-4030-9a31-b768e09ce293">

<img width="1280" alt="Screen Shot 2023-05-15 at 11 23 05 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/fc31deb5-e595-4e64-8665-f8d97b4c4343">

- After the rake task process_jobs is run, Job ID: 335 is processed and now has a status of "complete" and Results contains the "Download" url for the CSV file:

<img width="1280" alt="Screen Shot 2023-05-16 at 12 58 38 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/c1644212-7174-4af2-bc10-49759e4c4ac2">

<img width="1280" alt="Screen Shot 2023-05-16 at 1 00 46 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/9964fea5-5d36-4bd6-bd8c-6443156f3803">

When a background job contains an error, such as an SQL syntax error in Job ID: 964, the queued job status is set to "error", and the user error message is displayed:

<img width="1280" alt="Screen Shot 2023-05-15 at 11 26 37 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/daa12a6e-9129-4046-8ea3-23a41cdd31ae">

<img width="1280" alt="Screen Shot 2023-05-16 at 1 03 10 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/61ce9eec-a2b4-40ff-9859-98b4f02dc5ee">













