### PR TITLE
AACT-548: Make the BackgroundJob tests pass

### DIFF
--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -34,6 +34,10 @@ jobs:
       DB_NAME: aact_test
       AACT_ADMIN_DATABASE_URL: postgres://rails:password@localhost:5432/aact_admin_test
       AACT_PUBLIC_DATABASE_URL: postgres://rails:password@localhost:5432/aact_public_test
+      DIGITALOCEAN_ACCESS_KEY_ID: ${{ secrets.DIGITALOCEAN_ACCESS_KEY_ID }}
+      DIGITALOCEAN_SECRET_ACCESS_KEY: ${{ secrets.DIGITALOCEAN_SECRET_ACCESS_KEY }}
+      DIGITALOCEAN_REGION: us-east-1
+      DIGITALOCEAN_BUCKET: aact-dev
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Build config/connections.yml
         run: |
           echo "public:" >> config/connections.yml
+          echo "  encoding: utf8" >> config/connections.yml
+          echo "  adapter: postgresql" >> config/connections.yml
           echo "  host: localhost" >> config/connections.yml
           echo "  port: 5432" >> config/connections.yml
           echo "  database: aact_public_test" >> config/connections.yml

--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -82,5 +82,5 @@ jobs:
       - name: Run tests
         run: |
           mkdir tmp
-          touch tmp/${{ id }}.csv
+          touch tmp/#{id}.csv
           bundle exec rspec   

--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -78,9 +78,13 @@ jobs:
           echo "  user: rails" >> config/connections.yml
           echo "  password: password" >> config/connections.yml
 
-      # Add or replace test runners here
-      - name: Run tests
+      # Add or replace temporary directory/file here
+      - name: Create temp/file
         run: |
           mkdir tmp
           touch tmp/#{id}.csv
-          bundle exec rspec   
+          
+      # Add or replace test runners here
+      - name: Run tests
+        run: |
+          bundle exec rspec

--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -80,4 +80,7 @@ jobs:
 
       # Add or replace test runners here
       - name: Run tests
-        run: bundle exec rspec   
+        run: |
+          mkdir tmp
+          touch tmp/${{ id }}.csv
+          bundle exec rspec   

--- a/.github/workflows/build-and-test-not-master.yml
+++ b/.github/workflows/build-and-test-not-master.yml
@@ -78,12 +78,6 @@ jobs:
           echo "  user: rails" >> config/connections.yml
           echo "  password: password" >> config/connections.yml
 
-      # Add or replace temporary directory/file here
-      - name: Create temp/file
-        run: |
-          mkdir tmp
-          touch tmp/#{id}.csv
-          
       # Add or replace test runners here
       - name: Run tests
         run: |

--- a/app/models/background_job/db_query.rb
+++ b/app/models/background_job/db_query.rb
@@ -46,9 +46,6 @@ class BackgroundJob::DbQuery < BackgroundJob
         
     # if the background job status is "error", show the user error message
     rescue StandardError => e
-      puts 'These two "puts" are for testing purposes only.'
-      puts e.message
-      puts e.backtrace
       update(status: "error", logs: e.message, user_error_message: "There was an error, please contact us.")
     end    
   end  

--- a/app/models/background_job/db_query.rb
+++ b/app/models/background_job/db_query.rb
@@ -46,6 +46,7 @@ class BackgroundJob::DbQuery < BackgroundJob
         
     # if the background job status is "error", show the user error message
     rescue StandardError => e
+      puts 'These two "puts" are for testing purposes only.'
       puts e.message
       puts e.backtrace
       update(status: "error", logs: e.message, user_error_message: "There was an error, please contact us.")

--- a/app/models/background_job/db_query.rb
+++ b/app/models/background_job/db_query.rb
@@ -46,6 +46,8 @@ class BackgroundJob::DbQuery < BackgroundJob
         
     # if the background job status is "error", show the user error message
     rescue StandardError => e
+      puts e.message
+      puts e.backtrace
       update(status: "error", logs: e.message, user_error_message: "There was an error, please contact us.")
     end    
   end  

--- a/app/models/background_job/db_query.rb
+++ b/app/models/background_job/db_query.rb
@@ -21,6 +21,9 @@ class BackgroundJob::DbQuery < BackgroundJob
         csv << CSV.generate_line(rows)
       end
       
+      # create a temporary directory "tmp" unless it already exists
+      Dir.mkdir('tmp') unless Dir.exists?('tmp')
+
       filename = "tmp/#{id}.csv"
 
       f = File.open(filename, 'w')

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   factory :background_job, class: BackgroundJob do
     user_id { 1 }
     status { "pending" }
-    logs { "Error string." }
+    logs { "Logs string." }
     data { { 'query'=>'SELECT nct_id, study_type, brief_title, enrollment, has_dmc, completion_date, updated_at FROM studies LIMIT 18;' } }
     url { "https://aact-dev.nyc3.digitaloceanspaces.com/ky8i7qmv3o8prmhwginfr4fxxnx1" }
   end
@@ -11,7 +11,7 @@ FactoryBot.define do
   factory :background_job_db_query, class: BackgroundJob::DbQuery do
     user_id { 2 }
     status { "pending" }
-    logs { "Error string." }
+    logs { "Logs string." }
     data { { 'query'=>'SELECT nct_id, study_type, brief_title, enrollment, has_dmc, completion_date, updated_at FROM studies LIMIT 18;' } }
     url { "https://aact-dev.nyc3.digitaloceanspaces.com/ky8i7qmv3o8prmhwginfr4fxxnx1" }
   end


### PR DESCRIPTION
Fixed the following two FAILs when running the RSpec tests using the GitHub workflow file build-and-test-not-master.yml:

`rspec ./spec/models/background_job/db_query_spec.rb:9 # BackgroundJob::DbQuery#process should complete successfully when there is a valid SQL query`

`rspec ./spec/models/background_job/db_query_spec.rb:17 # BackgroundJob::DbQuery#process should update the status to "error" for the user when the SQL query is invalid`

Including these **2 BackgroundJob failures**, there is a total of **85 failures**:

<img width="1273" alt="Screen Shot 2023-08-29 at 11 34 30 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/0bb2b535-1d80-4e3a-9a74-d6705d3e7a3b">

<img width="1273" alt="Screen Shot 2023-08-29 at 11 00 09 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/d2e484db-502b-451a-bf1a-6eb9ae1e2849">

I de-bugged the code by adding print statements to find what caused the errors:

<img width="1244" alt="Screen Shot 2023-08-18 at 3 43 51 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/382ed991-c808-4056-a867-aec776b9612c">

<img width="1273" alt="Screen Shot 2023-08-29 at 10 54 56 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/1c035850-d5ec-41e5-9997-085546f3785e">

I modified the GitHub workflow file to add a temporary directory and file to store the output csv when the BackgroundJob::DbQuery#process method is called:
 
<img width="1273" alt="Screen Shot 2023-08-29 at 11 30 05 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/4e7261c3-e515-4a30-8f0a-693c551cd813">

The **two tests PASS**. Now, there is a total of **83 non-BackgroundJob failures**:

<img width="1273" alt="Screen Shot 2023-08-29 at 11 28 20 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/97e7dc5c-2aa9-42e1-b5b2-668bffa634d3">

<img width="1273" alt="Screen Shot 2023-08-29 at 11 33 16 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/9d624cf1-db21-4848-845b-0c6abfb883fc">





