### PR TITLE
AACT-156: Change user to non-root in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM ruby:2.7.7
 
+# Create user and set ownership and permissions as required
+RUN adduser -D aact && chown -R aact /app
+# ... copy application files
+USER aact
+ENTRYPOINT ["/app"]
+
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 # RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --no-check-certificate --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
 FROM ruby:2.7.7
 
-# Create user and set ownership and permissions as required
-RUN adduser -D aact && chown -R aact /app
-# ... copy application files
-USER aact
-ENTRYPOINT ["/app"]
-
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-# RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --no-check-certificate --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client telnet vim zip cron graphviz wget
 
 RUN mkdir /app
@@ -19,9 +11,15 @@ COPY Gemfile.lock /app/Gemfile.lock
 RUN gem install bundler -v 1.17.3
 RUN bundle install
 
+# Create non-root user and set ownership and permissions as required
+RUN adduser --disabled-password aact && chown -R aact /app
+
 COPY . /app
 
 RUN ln -s /config/connections.yml /app/config/connections.yml
+
+# Switch to the user
+USER aact
 
 EXPOSE 3000
 


### PR DESCRIPTION
- Running as the root user in docker creates a security vulnerability.

- Updated the Dockerfile so that we specify a different user to run our code inside docker.

<img width="1243" alt="Screen Shot 2023-10-09 at 10 12 36 AM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/d129e7e0-a40d-4b0d-8de7-310b165832b7">
