### PR TITLE
Feat/aact 634/add result agreement data mapper methods to the processor

### DIFF
--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -261,6 +261,17 @@ class StudyJsonRecord::ProcessorV2
   end
 
   def result_agreement_data
+    ident = protocol_section['identificationModule']
+    nct_id = ident['nctId']
+    certain_agreement = results_section.dig('moreInfoModule', 'certainAgreement')
+    
+    {
+      nct_id: nct_id,
+      pi_employee: certain_agreement['piSponsorEmployee'],
+      restrictive_agreement: certain_agreement['restrictiveAgreement'],
+      restriction_type: certain_agreement['restrictionType'],
+      other_details: certain_agreement['otherDetails']
+    }
   end
 
   def result_contact_data

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -68,6 +68,106 @@ class StudyJsonRecord::ProcessorV2
   end
   
   def study_data
+    status = protocol_section['StatusModule']
+    ident = protocol_section['IdentificationModule']
+    design = key_check(protocol_section['DesignModule'])
+    oversight = key_check(protocol_section['OversightModule'])
+    ipd_sharing = key_check(protocol_section['IPDSharingStatementModule'])
+    study_posted = status['StudyFirstPostDateStruct']
+    results_posted = key_check(status['ResultsFirstPostDateStruct'])
+    disp_posted = key_check(status['DispFirstPostDateStruct'])
+    last_posted = status['LastUpdatePostDateStruct']
+    start_date = key_check(status['StartDateStruct'])
+    completion_date = key_check(status['CompletionDateStruct'])
+    primary_completion_date = key_check(status['PrimaryCompletionDateStruct'])
+    results = results_section || {}
+    baseline = key_check(results['BaselineCharacteristicsModule'])
+    enrollment = key_check(design['EnrollmentInfo'])
+    expanded_access = status.dig('ExpandedAccessInfo', 'HasExpandedAccess')
+    expanded = key_check(design['ExpandedAccessTypes'])
+    biospec = key_check(design['BioSpec'])
+    arms_intervention = key_check(protocol_section['ArmsInterventionsModule'])
+    study_type = design['StudyType']
+    patient_registry = design['PatientRegistry'] || ''
+    study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i
+    group_list = key_check(arms_intervention['ArmGroupList'])
+    groups = group_list['ArmGroup'] || []
+    num_of_groups = groups.count == 0 ? nil : groups.count
+    arms_count = study_type =~ /Interventional/i ? num_of_groups : nil
+    groups_count = arms_count ? nil : num_of_groups
+    phase_list = key_check(design['PhaseList'])['Phase']
+    phase_list = phase_list.join('/') if phase_list
+
+    {
+      nct_id: nct_id,
+      nlm_download_date_description: nil,
+      study_first_submitted_date: get_date(status['StudyFirstSubmitDate']),
+      results_first_submitted_date: get_date(status['ResultsFirstSubmitDate']),
+      disposition_first_submitted_date: get_date(status['DispFirstSubmitDate']),
+      last_update_submitted_date: get_date(status['LastUpdateSubmitDate']),
+      study_first_submitted_qc_date: status['StudyFirstSubmitQCDate'],
+      study_first_posted_date: study_posted['StudyFirstPostDate'],
+      study_first_posted_date_type: study_posted['StudyFirstPostDateType'],
+      results_first_submitted_qc_date: status['ResultsFirstSubmitQCDate'],
+      results_first_posted_date: results_posted['ResultsFirstPostDate'],
+      results_first_posted_date_type: results_posted['ResultsFirstPostDateType'],
+      disposition_first_submitted_qc_date: status['DispFirstSubmitQCDate'],
+      disposition_first_posted_date: disp_posted['DispFirstPostDate'],
+      disposition_first_posted_date_type: disp_posted['DispFirstPostDateType'],
+      last_update_submitted_qc_date: status['LastUpdateSubmitDate'], # this should not go here
+      last_update_posted_date: last_posted['LastUpdatePostDate'],
+      last_update_posted_date_type: last_posted['LastUpdatePostDateType'],
+      delayed_posting: status['DelayedPosting'],
+      start_month_year: start_date['StartDate'],
+      start_date_type: start_date['StartDateType'],
+      start_date: convert_date(start_date['StartDate']),
+      verification_month_year: status['StatusVerifiedDate'],
+      verification_date: convert_date(status['StatusVerifiedDate']),
+      completion_month_year: completion_date['CompletionDate'],
+      completion_date_type: completion_date['CompletionDateType'],
+      completion_date: convert_date(completion_date['CompletionDate']),
+      primary_completion_month_year: primary_completion_date['PrimaryCompletionDate'],
+      primary_completion_date_type: primary_completion_date['PrimaryCompletionDateType'],
+      primary_completion_date: convert_date(primary_completion_date['PrimaryCompletionDate']),
+      target_duration: design['TargetDuration'],
+      study_type: study_type,
+      acronym: ident['Acronym'],
+      baseline_population: baseline['BaselinePopulationDescription'],
+      brief_title: ident['BriefTitle'],
+      official_title: ident['OfficialTitle'],
+      overall_status: status['OverallStatus'],
+      last_known_status: status['LastKnownStatus'],
+      phase: phase_list,
+      enrollment: enrollment['EnrollmentCount'],
+      enrollment_type: enrollment['EnrollmentType'],
+      source: ident.dig('Organization', 'OrgFullName'),
+      source_class: ident.dig('Organization', 'OrgClass'),
+      limitations_and_caveats: key_check(results['MoreInfoModule'])['LimitationsAndCaveatsDescription'],
+      number_of_arms: arms_count,
+      number_of_groups: groups_count,
+      why_stopped: status['WhyStopped'],
+      has_expanded_access: get_boolean(expanded_access),
+      expanded_access_nctid: status.dig('ExpandedAccessInfo', 'ExpandedAccessNCTId'),
+      expanded_access_status_for_nctid: status.dig('ExpandedAccessInfo', 'ExpandedAccessStatusForNCTId'),
+      expanded_access_type_individual: get_boolean(expanded['ExpAccTypeIndividual']),
+      expanded_access_type_intermediate: get_boolean(expanded['ExpAccTypeIntermediate']),
+      expanded_access_type_treatment: get_boolean(expanded['ExpAccTypeTreatment']),
+      has_dmc: get_boolean(oversight['OversightHasDMC']),
+      is_fda_regulated_drug: get_boolean(oversight['IsFDARegulatedDrug']),
+      is_fda_regulated_device: get_boolean(oversight['IsFDARegulatedDevice']),
+      is_unapproved_device: get_boolean(oversight['IsUnapprovedDevice']),
+      is_ppsd: get_boolean(oversight['IsPPSD']),
+      is_us_export: get_boolean(oversight['IsUSExport']),
+      fdaaa801_violation: get_boolean(oversight['FDAAA801Violation']),
+      biospec_retention: biospec['BioSpecRetention'],
+      biospec_description: biospec['BioSpecDescription'],
+      ipd_time_frame: ipd_sharing['IPDSharingTimeFrame'],
+      ipd_access_criteria: ipd_sharing['IPDSharingAccessCriteria'],
+      ipd_url: ipd_sharing['IPDSharingURL'],
+      plan_to_share_ipd: ipd_sharing['IPDSharing'],
+      plan_to_share_ipd_description: ipd_sharing['IPDSharingDescription'],
+      baseline_type_units_analyzed: baseline['BaselineTypeUnitsAnalyzed']
+    }
   end
 
   def design_groups_data
@@ -172,6 +272,41 @@ class StudyJsonRecord::ProcessorV2
   end
 
   def drop_withdrawals_data
+  end
+
+  ###### Utils ######
+
+  def key_check(key)
+    key ||= {}
+  end
+
+  def get_date(str)
+    begin
+      str.try(:to_date)
+    rescue
+      nil
+    end
+  end
+
+  def convert_date(str)
+    return unless str
+
+    converted_date = get_date(str)
+    return unless converted_date
+    return converted_date.end_of_month if is_missing_the_day?(str)
+
+    converted_date
+  end
+
+  def is_missing_the_day?(str)
+    # use this method on string representations of dates.  If only one space in the string, then the day is not provided.
+    (str.count ' ') == 1
+  end
+
+  def get_boolean(val)
+    return nil unless val
+    return true if val.downcase=='yes'||val.downcase=='y'||val.downcase=='true'
+    return false if val.downcase=='no'||val.downcase=='n'||val.downcase=='false'
   end
   
 end

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -82,6 +82,7 @@ class StudyJsonRecord::ProcessorV2
     completion_date = key_check(status['completionDateStruct'])
     primary_completion_date = key_check(status['primaryCompletionDateStruct'])
     results = results_section || {}
+    more_info = results['moreInfoModule']
     baseline = key_check(results['baselineCharacteristicsModule'])
     enrollment = key_check(design['enrollmentInfo'])
     expanded_access = status.dig('expandedAccessInfo', 'hasExpandedAccess')
@@ -91,19 +92,11 @@ class StudyJsonRecord::ProcessorV2
     study_type = design['studyType']
     patient_registry = design['patientRegistry'] || ''
     study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i
-    
-    # group_list = key_check(arms_intervention['armGroupList'])  # ???  does not exist, maybe should be armGroups
-    group_list = key_check(arms_intervention['armGroups'])
-    
-    groups = group_list['armGroup'] || []   # ??? does not exist
-    
+    groups = key_check(arms_intervention['armGroups'])
     num_of_groups = groups.count == 0 ? nil : groups.count
     arms_count = study_type =~ /Interventional/i ? num_of_groups : nil
     groups_count = arms_count ? nil : num_of_groups
-    
-    # phase_list = key_check(design['phaseList'])['phase']  # ???
     phase_list = key_check(design['phases'])
-    
     phase_list = phase_list.join('/') if phase_list
 
     {
@@ -150,7 +143,7 @@ class StudyJsonRecord::ProcessorV2
       enrollment_type: enrollment['type'],
       source: ident.dig('organization', 'fullName'),
       source_class: ident.dig('organization', 'class'),
-      limitations_and_caveats: key_check(results['moreInfoModule'])['limitationsAndCaveatsDescription'],  # ???
+      limitations_and_caveats: key_check(more_info['limitationsAndCaveats'])['description'],
       number_of_arms: arms_count,
       number_of_groups: groups_count,
       why_stopped: status['whyStopped'],

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -68,105 +68,106 @@ class StudyJsonRecord::ProcessorV2
   end
   
   def study_data
-    status = protocol_section['StatusModule']
-    ident = protocol_section['IdentificationModule']
-    design = key_check(protocol_section['DesignModule'])
-    oversight = key_check(protocol_section['OversightModule'])
-    ipd_sharing = key_check(protocol_section['IPDSharingStatementModule'])
-    study_posted = status['StudyFirstPostDateStruct']
-    results_posted = key_check(status['ResultsFirstPostDateStruct'])
-    disp_posted = key_check(status['DispFirstPostDateStruct'])
-    last_posted = status['LastUpdatePostDateStruct']
-    start_date = key_check(status['StartDateStruct'])
-    completion_date = key_check(status['CompletionDateStruct'])
-    primary_completion_date = key_check(status['PrimaryCompletionDateStruct'])
+    ident = protocol_section['identificationModule']
+    nct_id = ident['nctId']
+    status = protocol_section['statusModule']
+    design = key_check(protocol_section['designModule'])
+    oversight = key_check(protocol_section['oversightModule'])
+    ipd_sharing = key_check(protocol_section['ipdSharingStatementModule'])
+    study_posted = status['studyFirstPostDateStruct']
+    results_posted = key_check(status['resultsFirstPostDateStruct']) # ???
+    disp_posted = key_check(status['dispFirstPostDateStruct']) # ???
+    last_posted = status['lastUpdatePostDateStruct']
+    start_date = key_check(status['startDateStruct'])
+    completion_date = key_check(status['completionDateStruct'])
+    primary_completion_date = key_check(status['primaryCompletionDateStruct'])
     results = results_section || {}
-    baseline = key_check(results['BaselineCharacteristicsModule'])
-    enrollment = key_check(design['EnrollmentInfo'])
-    expanded_access = status.dig('ExpandedAccessInfo', 'HasExpandedAccess')
-    expanded = key_check(design['ExpandedAccessTypes'])
-    biospec = key_check(design['BioSpec'])
-    arms_intervention = key_check(protocol_section['ArmsInterventionsModule'])
-    study_type = design['StudyType']
-    patient_registry = design['PatientRegistry'] || ''
-    study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i
-    group_list = key_check(arms_intervention['ArmGroupList'])
-    groups = group_list['ArmGroup'] || []
+    baseline = key_check(results['baselineCharacteristicsModule']) # ???
+    enrollment = key_check(design['enrollmentInfo'])
+    expanded_access = status.dig('expandedAccessInfo', 'hasExpandedAccess')
+    expanded = key_check(design['expandedAccessTypes']) # ???
+    biospec = key_check(design['bioSpec']) # ???
+    arms_intervention = key_check(protocol_section['armsInterventionsModule'])
+    study_type = design['studyType']
+    patient_registry = design['patientRegistry'] || '' # ???
+    study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i  # ???
+    group_list = key_check(arms_intervention['armGroupList'])  # ???
+    groups = group_list['armGroup'] || []   # ???
     num_of_groups = groups.count == 0 ? nil : groups.count
     arms_count = study_type =~ /Interventional/i ? num_of_groups : nil
     groups_count = arms_count ? nil : num_of_groups
-    phase_list = key_check(design['PhaseList'])['Phase']
+    phase_list = key_check(design['phaseList'])['phase']  # ???
     phase_list = phase_list.join('/') if phase_list
 
     {
       nct_id: nct_id,
       nlm_download_date_description: nil,
-      study_first_submitted_date: get_date(status['StudyFirstSubmitDate']),
-      results_first_submitted_date: get_date(status['ResultsFirstSubmitDate']),
-      disposition_first_submitted_date: get_date(status['DispFirstSubmitDate']),
-      last_update_submitted_date: get_date(status['LastUpdateSubmitDate']),
-      study_first_submitted_qc_date: status['StudyFirstSubmitQCDate'],
-      study_first_posted_date: study_posted['StudyFirstPostDate'],
-      study_first_posted_date_type: study_posted['StudyFirstPostDateType'],
-      results_first_submitted_qc_date: status['ResultsFirstSubmitQCDate'],
-      results_first_posted_date: results_posted['ResultsFirstPostDate'],
-      results_first_posted_date_type: results_posted['ResultsFirstPostDateType'],
-      disposition_first_submitted_qc_date: status['DispFirstSubmitQCDate'],
-      disposition_first_posted_date: disp_posted['DispFirstPostDate'],
-      disposition_first_posted_date_type: disp_posted['DispFirstPostDateType'],
-      last_update_submitted_qc_date: status['LastUpdateSubmitDate'], # this should not go here
-      last_update_posted_date: last_posted['LastUpdatePostDate'],
-      last_update_posted_date_type: last_posted['LastUpdatePostDateType'],
-      delayed_posting: status['DelayedPosting'],
-      start_month_year: start_date['StartDate'],
-      start_date_type: start_date['StartDateType'],
-      start_date: convert_date(start_date['StartDate']),
-      verification_month_year: status['StatusVerifiedDate'],
-      verification_date: convert_date(status['StatusVerifiedDate']),
-      completion_month_year: completion_date['CompletionDate'],
-      completion_date_type: completion_date['CompletionDateType'],
-      completion_date: convert_date(completion_date['CompletionDate']),
-      primary_completion_month_year: primary_completion_date['PrimaryCompletionDate'],
-      primary_completion_date_type: primary_completion_date['PrimaryCompletionDateType'],
-      primary_completion_date: convert_date(primary_completion_date['PrimaryCompletionDate']),
-      target_duration: design['TargetDuration'],
+      results_first_submitted_date: get_date(status['resultsFirstSubmitDate']),   # ???
+      disposition_first_submitted_date: get_date(status['dispFirstSubmitDate']),  # ???
+      last_update_submitted_date: get_date(status['lastUpdateSubmitDate']),
+      study_first_submitted_date: get_date(status['studyFirstSubmitDate']),
+      study_first_submitted_qc_date: status['studyFirstSubmitQcDate'],
+      study_first_posted_date: study_posted['date'],
+      study_first_posted_date_type: study_posted['type'],
+      results_first_submitted_qc_date: status['resultsFirstSubmitQCDate'],   # ???
+      results_first_posted_date: results_posted['resultsFirstPostDate'],     # ???
+      results_first_posted_date_type: results_posted['resultsFirstPostDateType'],   # ???
+      disposition_first_submitted_qc_date: status['dispFirstSubmitQCDate'],  # ???
+      disposition_first_posted_date: disp_posted['dispFirstPostDate'],       # ???
+      disposition_first_posted_date_type: disp_posted['dispFirstPostDateType'],     # ???
+      last_update_submitted_qc_date: status['lastUpdateSubmitDate'], # this should not go here (Ramiro comment)
+      last_update_posted_date: last_posted['date'],
+      last_update_posted_date_type: last_posted['type'],
+      delayed_posting: status['delayedPosting'],     # ???
+      start_month_year: start_date['date'],
+      start_date_type: start_date['type'],
+      start_date: convert_date(start_date['date']),
+      verification_month_year: status['statusVerifiedDate'],
+      verification_date: convert_date(status['statusVerifiedDate']),
+      completion_month_year: completion_date['date'],
+      completion_date_type: completion_date['type'],
+      completion_date: convert_date(completion_date['date']),
+      primary_completion_month_year: primary_completion_date['date'],
+      primary_completion_date_type: primary_completion_date['type'],
+      primary_completion_date: convert_date(primary_completion_date['date']),
+      target_duration: design['targetDuration'],   # ???
       study_type: study_type,
-      acronym: ident['Acronym'],
-      baseline_population: baseline['BaselinePopulationDescription'],
-      brief_title: ident['BriefTitle'],
-      official_title: ident['OfficialTitle'],
-      overall_status: status['OverallStatus'],
-      last_known_status: status['LastKnownStatus'],
+      acronym: ident['acronym'],
+      baseline_population: baseline['baselinePopulationDescription'],   # ???
+      brief_title: ident['briefTitle'],
+      official_title: ident['officialTitle'],
+      overall_status: status['overallStatus'],
+      last_known_status: status['lastKnownStatus'],   # ???
       phase: phase_list,
-      enrollment: enrollment['EnrollmentCount'],
-      enrollment_type: enrollment['EnrollmentType'],
-      source: ident.dig('Organization', 'OrgFullName'),
-      source_class: ident.dig('Organization', 'OrgClass'),
-      limitations_and_caveats: key_check(results['MoreInfoModule'])['LimitationsAndCaveatsDescription'],
+      enrollment: enrollment['count'],
+      enrollment_type: enrollment['type'],
+      source: ident.dig('organization', 'fullName'),
+      source_class: ident.dig('organization', 'class'),
+      limitations_and_caveats: key_check(results['moreInfoModule'])['limitationsAndCaveatsDescription'],  # ???
       number_of_arms: arms_count,
       number_of_groups: groups_count,
-      why_stopped: status['WhyStopped'],
+      why_stopped: status['whyStopped'],   # ???
       has_expanded_access: get_boolean(expanded_access),
-      expanded_access_nctid: status.dig('ExpandedAccessInfo', 'ExpandedAccessNCTId'),
-      expanded_access_status_for_nctid: status.dig('ExpandedAccessInfo', 'ExpandedAccessStatusForNCTId'),
-      expanded_access_type_individual: get_boolean(expanded['ExpAccTypeIndividual']),
-      expanded_access_type_intermediate: get_boolean(expanded['ExpAccTypeIntermediate']),
-      expanded_access_type_treatment: get_boolean(expanded['ExpAccTypeTreatment']),
-      has_dmc: get_boolean(oversight['OversightHasDMC']),
-      is_fda_regulated_drug: get_boolean(oversight['IsFDARegulatedDrug']),
-      is_fda_regulated_device: get_boolean(oversight['IsFDARegulatedDevice']),
-      is_unapproved_device: get_boolean(oversight['IsUnapprovedDevice']),
-      is_ppsd: get_boolean(oversight['IsPPSD']),
-      is_us_export: get_boolean(oversight['IsUSExport']),
-      fdaaa801_violation: get_boolean(oversight['FDAAA801Violation']),
-      biospec_retention: biospec['BioSpecRetention'],
-      biospec_description: biospec['BioSpecDescription'],
-      ipd_time_frame: ipd_sharing['IPDSharingTimeFrame'],
-      ipd_access_criteria: ipd_sharing['IPDSharingAccessCriteria'],
-      ipd_url: ipd_sharing['IPDSharingURL'],
-      plan_to_share_ipd: ipd_sharing['IPDSharing'],
-      plan_to_share_ipd_description: ipd_sharing['IPDSharingDescription'],
-      baseline_type_units_analyzed: baseline['BaselineTypeUnitsAnalyzed']
+      expanded_access_nctid: status.dig('expandedAccessInfo', 'expandedAccessNCTId'),      # ??? expandedAccessNCTId ?
+      expanded_access_status_for_nctid: status.dig('expandedAccessInfo', 'expandedAccessStatusForNCTId'),  # ??? expandedAccessStatusForNCTId ?
+      expanded_access_type_individual: get_boolean(expanded['expAccTypeIndividual']),      # ???
+      expanded_access_type_intermediate: get_boolean(expanded['expAccTypeIntermediate']),  # ???
+      expanded_access_type_treatment: get_boolean(expanded['expAccTypeTreatment']),        # ???
+      has_dmc: get_boolean(oversight['oversightHasDMC']),
+      is_fda_regulated_drug: get_boolean(oversight['isFdaRegulatedDrug']),
+      is_fda_regulated_device: get_boolean(oversight['isFdaRegulatedDevice']),
+      is_unapproved_device: get_boolean(oversight['isUnapprovedDevice']),       # ???
+      is_ppsd: get_boolean(oversight['isPPSD']),    # ???
+      is_us_export: get_boolean(oversight['isUSExport']),   # ??? 
+      fdaaa801_violation: get_boolean(oversight['FDAAA801Violation']),   # ??? 
+      biospec_retention: biospec['bioSpecRetention'],       # ???
+      biospec_description: biospec['bioSpecDescription'],   # ???
+      ipd_time_frame: ipd_sharing['timeFrame'],
+      ipd_access_criteria: ipd_sharing['accessCriteria'],
+      ipd_url: ipd_sharing['url'],
+      plan_to_share_ipd: ipd_sharing['ipdSharing'],  
+      plan_to_share_ipd_description: ipd_sharing['description'],
+      baseline_type_units_analyzed: baseline['baselineTypeUnitsAnalyzed']   # ???
     }
   end
 

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -75,50 +75,57 @@ class StudyJsonRecord::ProcessorV2
     oversight = key_check(protocol_section['oversightModule'])
     ipd_sharing = key_check(protocol_section['ipdSharingStatementModule'])
     study_posted = status['studyFirstPostDateStruct']
-    results_posted = key_check(status['resultsFirstPostDateStruct']) # ???
-    disp_posted = key_check(status['dispFirstPostDateStruct']) # ???
+    results_posted = key_check(status['resultsFirstPostDateStruct'])
+    disp_posted = key_check(status['dispFirstPostDateStruct'])
     last_posted = status['lastUpdatePostDateStruct']
     start_date = key_check(status['startDateStruct'])
     completion_date = key_check(status['completionDateStruct'])
     primary_completion_date = key_check(status['primaryCompletionDateStruct'])
     results = results_section || {}
-    baseline = key_check(results['baselineCharacteristicsModule']) # ???
+    baseline = key_check(results['baselineCharacteristicsModule'])
     enrollment = key_check(design['enrollmentInfo'])
     expanded_access = status.dig('expandedAccessInfo', 'hasExpandedAccess')
-    expanded = key_check(design['expandedAccessTypes']) # ???
-    biospec = key_check(design['bioSpec']) # ???
+    expanded = key_check(design['expandedAccessTypes'])
+    biospec = key_check(design['bioSpec'])
     arms_intervention = key_check(protocol_section['armsInterventionsModule'])
     study_type = design['studyType']
-    patient_registry = design['patientRegistry'] || '' # ???
-    study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i  # ???
-    group_list = key_check(arms_intervention['armGroupList'])  # ???
-    groups = group_list['armGroup'] || []   # ???
+    patient_registry = design['patientRegistry'] || ''
+    study_type = "#{study_type} [Patient Registry]" if patient_registry =~ /Yes/i
+    
+    # group_list = key_check(arms_intervention['armGroupList'])  # ???  does not exist, maybe should be armGroups
+    group_list = key_check(arms_intervention['armGroups'])
+    
+    groups = group_list['armGroup'] || []   # ??? does not exist
+    
     num_of_groups = groups.count == 0 ? nil : groups.count
     arms_count = study_type =~ /Interventional/i ? num_of_groups : nil
     groups_count = arms_count ? nil : num_of_groups
-    phase_list = key_check(design['phaseList'])['phase']  # ???
+    
+    # phase_list = key_check(design['phaseList'])['phase']  # ???
+    phase_list = key_check(design['phases'])
+    
     phase_list = phase_list.join('/') if phase_list
 
     {
       nct_id: nct_id,
       nlm_download_date_description: nil,
-      results_first_submitted_date: get_date(status['resultsFirstSubmitDate']),   # ???
-      disposition_first_submitted_date: get_date(status['dispFirstSubmitDate']),  # ???
+      results_first_submitted_date: get_date(status['resultsFirstSubmitDate']),
+      disposition_first_submitted_date: get_date(status['dispFirstSubmitDate']),
       last_update_submitted_date: get_date(status['lastUpdateSubmitDate']),
       study_first_submitted_date: get_date(status['studyFirstSubmitDate']),
       study_first_submitted_qc_date: status['studyFirstSubmitQcDate'],
       study_first_posted_date: study_posted['date'],
       study_first_posted_date_type: study_posted['type'],
-      results_first_submitted_qc_date: status['resultsFirstSubmitQCDate'],   # ???
-      results_first_posted_date: results_posted['resultsFirstPostDate'],     # ???
-      results_first_posted_date_type: results_posted['resultsFirstPostDateType'],   # ???
-      disposition_first_submitted_qc_date: status['dispFirstSubmitQCDate'],  # ???
-      disposition_first_posted_date: disp_posted['dispFirstPostDate'],       # ???
-      disposition_first_posted_date_type: disp_posted['dispFirstPostDateType'],     # ???
+      results_first_submitted_qc_date: status['resultsFirstSubmitQcDate'],
+      results_first_posted_date: results_posted['date'],
+      results_first_posted_date_type: results_posted['type'],
+      disposition_first_submitted_qc_date: status['dispFirstSubmitQcDate'],
+      disposition_first_posted_date: disp_posted['date'],
+      disposition_first_posted_date_type: disp_posted['type'],
       last_update_submitted_qc_date: status['lastUpdateSubmitDate'], # this should not go here (Ramiro comment)
       last_update_posted_date: last_posted['date'],
       last_update_posted_date_type: last_posted['type'],
-      delayed_posting: status['delayedPosting'],     # ???
+      delayed_posting: status['delayedPosting'],
       start_month_year: start_date['date'],
       start_date_type: start_date['type'],
       start_date: convert_date(start_date['date']),
@@ -130,14 +137,14 @@ class StudyJsonRecord::ProcessorV2
       primary_completion_month_year: primary_completion_date['date'],
       primary_completion_date_type: primary_completion_date['type'],
       primary_completion_date: convert_date(primary_completion_date['date']),
-      target_duration: design['targetDuration'],   # ???
+      target_duration: design['targetDuration'],
       study_type: study_type,
       acronym: ident['acronym'],
-      baseline_population: baseline['baselinePopulationDescription'],   # ???
+      baseline_population: baseline['populationDescription'],
       brief_title: ident['briefTitle'],
       official_title: ident['officialTitle'],
       overall_status: status['overallStatus'],
-      last_known_status: status['lastKnownStatus'],   # ???
+      last_known_status: status['lastKnownStatus'],
       phase: phase_list,
       enrollment: enrollment['count'],
       enrollment_type: enrollment['type'],
@@ -146,28 +153,28 @@ class StudyJsonRecord::ProcessorV2
       limitations_and_caveats: key_check(results['moreInfoModule'])['limitationsAndCaveatsDescription'],  # ???
       number_of_arms: arms_count,
       number_of_groups: groups_count,
-      why_stopped: status['whyStopped'],   # ???
+      why_stopped: status['whyStopped'],
       has_expanded_access: get_boolean(expanded_access),
-      expanded_access_nctid: status.dig('expandedAccessInfo', 'expandedAccessNCTId'),      # ??? expandedAccessNCTId ?
-      expanded_access_status_for_nctid: status.dig('expandedAccessInfo', 'expandedAccessStatusForNCTId'),  # ??? expandedAccessStatusForNCTId ?
-      expanded_access_type_individual: get_boolean(expanded['expAccTypeIndividual']),      # ???
-      expanded_access_type_intermediate: get_boolean(expanded['expAccTypeIntermediate']),  # ???
-      expanded_access_type_treatment: get_boolean(expanded['expAccTypeTreatment']),        # ???
+      expanded_access_nctid: status.dig('expandedAccessInfo', 'nctId'),
+      expanded_access_status_for_nctid: status.dig('expandedAccessInfo', 'statusForNctId'),
+      expanded_access_type_individual: get_boolean(expanded['individual']),
+      expanded_access_type_intermediate: get_boolean(expanded['intermediate']),
+      expanded_access_type_treatment: get_boolean(expanded['treatment']),
       has_dmc: get_boolean(oversight['oversightHasDMC']),
       is_fda_regulated_drug: get_boolean(oversight['isFdaRegulatedDrug']),
       is_fda_regulated_device: get_boolean(oversight['isFdaRegulatedDevice']),
-      is_unapproved_device: get_boolean(oversight['isUnapprovedDevice']),       # ???
-      is_ppsd: get_boolean(oversight['isPPSD']),    # ???
-      is_us_export: get_boolean(oversight['isUSExport']),   # ??? 
-      fdaaa801_violation: get_boolean(oversight['FDAAA801Violation']),   # ??? 
-      biospec_retention: biospec['bioSpecRetention'],       # ???
-      biospec_description: biospec['bioSpecDescription'],   # ???
+      is_unapproved_device: get_boolean(oversight['isUnapprovedDevice']),
+      is_ppsd: get_boolean(oversight['isPpsd']),
+      is_us_export: get_boolean(oversight['isUsExport']),
+      fdaaa801_violation: get_boolean(oversight['Fdaaa801Violation']),
+      biospec_retention: biospec['retention'],
+      biospec_description: biospec['description'],
       ipd_time_frame: ipd_sharing['timeFrame'],
       ipd_access_criteria: ipd_sharing['accessCriteria'],
       ipd_url: ipd_sharing['url'],
       plan_to_share_ipd: ipd_sharing['ipdSharing'],  
       plan_to_share_ipd_description: ipd_sharing['description'],
-      baseline_type_units_analyzed: baseline['baselineTypeUnitsAnalyzed']   # ???
+      baseline_type_units_analyzed: baseline['typeUnitsAnalyzed']
     }
   end
 

--- a/spec/models/study_json_record/processor_v2_spec.rb
+++ b/spec/models/study_json_record/processor_v2_spec.rb
@@ -1,19 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe StudyJsonRecord::ProcessorV2, type: :model do
-  describe 'brief_summary_data' do
+  before do
+   
+  end
 
-    it 'should test brief_summary_data' do
-      expected_data = {
-          nct_id: 'NCT03630471',
-          description: 'We will conduct a two-arm individually randomized controlled trial in six Government-run secondary schools in New Delhi. The targeted sample is 240 adolescents in grades 9-12 with persistent, elevated mental health difficulties and associated impact. Participants will receive either a brief problem-solving intervention delivered by lay counsellors (intervention), or enhanced usual care comprised of problem-solving booklets (control). Self-reported adolescent mental health difficulties and idiographic problems will be assessed at 6 weeks (co-primary outcomes) and again at 12 weeks post-randomization. In addition, adolescent-reported impact of mental health difficulties, perceived stress, mental wellbeing and clinical remission, as well as parent-reported adolescent mental health difficulties and impact scores, will be assessed at 6 and 12 weeks post-randomization. Parallel process evaluation, including estimations of the costs of delivering the interventions, will be conducted.'
-      }
+  context '#initialize' do
+    it 'should ' do
       hash = JSON.parse(File.read('spec/support/json_data/NCT03630471.json'))
       processor = StudyJsonRecord::ProcessorV2.new(hash)
-      expect(processor.brief_summary_data).to eq(expected_data)
+      expect(processor).to eq(hash)
     end
+    
+    it 'should ' do
+      
+      
+    end  
+  end
+  
+  context '#study_data' do
+    it 'should ' do
+      hash = JSON.parse(File.read('spec/support/json_data/NCT03630471.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      processor.study_data
+      expect(processor).to eq()
 
-
-
+    end
+    
+    it 'should ' do
+      
+    end  
   end
 end

--- a/spec/support/json_data/NCT02210780.json
+++ b/spec/support/json_data/NCT02210780.json
@@ -1,0 +1,2741 @@
+{
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT02210780",
+  "orgStudyIdInfo": {
+  "id": "R668-AD-1314"
+  },
+  "organization": {
+  "fullName": "Regeneron Pharmaceuticals",
+  "class": "INDUSTRY"
+  },
+  "briefTitle": "Study of Dupilumab and Immune Responses in Adults With Atopic Dermatitis (AD)",
+  "officialTitle": "A Randomized, Double-Blind, Placebo-Controlled, Study Investigating Vaccine Responses in Adults With Moderate to Severe Atopic Dermatitis Treated With Dupilumab"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2020-04",
+  "overallStatus": "COMPLETED",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2014-08-05",
+  "type": "ACTUAL"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2015-09-15",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2015-09-15",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2014-08-05",
+  "studyFirstSubmitQcDate": "2014-08-05",
+  "studyFirstPostDateStruct": {
+  "date": "2014-08-07",
+  "type": "ESTIMATED"
+  },
+  "resultsFirstSubmitDate": "2020-03-20",
+  "resultsFirstSubmitQcDate": "2020-04-23",
+  "resultsFirstPostDateStruct": {
+  "date": "2020-05-07",
+  "type": "ACTUAL"
+  },
+  "dispFirstSubmitDate": "2017-02-07",
+  "dispFirstSubmitQcDate": "2017-02-07",
+  "dispFirstPostDateStruct": {
+  "date": "2017-02-08",
+  "type": "ESTIMATED"
+  },
+  "lastUpdateSubmitDate": "2020-04-23",
+  "lastUpdatePostDateStruct": {
+  "date": "2020-05-07",
+  "type": "ACTUAL"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "SPONSOR"
+  },
+  "leadSponsor": {
+  "name": "Regeneron Pharmaceuticals",
+  "class": "INDUSTRY"
+  },
+  "collaborators": [
+  {
+  "name": "Sanofi",
+  "class": "INDUSTRY"
+  }
+  ]
+  },
+  "oversightModule": {
+  "oversightHasDmc": true
+  },
+  "descriptionModule": {
+  "briefSummary": "This was a 32-week, randomized, double-blind, placebo-controlled, parallel-group study assessing immunization responses to vaccination in adults with moderate to severe atopic dermatitis who are treated with subcutaneous dupilumab."
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Atopic Dermatitis"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "PHASE2"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "primaryPurpose": "TREATMENT",
+  "maskingInfo": {
+  "masking": "TRIPLE",
+  "whoMasked": [
+  "PARTICIPANT",
+  "INVESTIGATOR",
+  "OUTCOMES_ASSESSOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 194,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "Placebo qw",
+  "type": "EXPERIMENTAL",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15.",
+  "interventionNames": [
+  "Drug: Placebo"
+  ]
+  },
+  {
+  "label": "Dupilumab 300 mg qw",
+  "type": "EXPERIMENTAL",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15.",
+  "interventionNames": [
+  "Drug: Dupilumab"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "DRUG",
+  "name": "Dupilumab",
+  "description": "Administered via subcutaneous injection.",
+  "armGroupLabels": [
+  "Dupilumab 300 mg qw"
+  ],
+  "otherNames": [
+  "REGN668",
+  "SAR231893",
+  "Dupixent"
+  ]
+  },
+  {
+  "type": "DRUG",
+  "name": "Placebo",
+  "description": "An inactive substance containing no medicine administered via subcutaneous injection.",
+  "armGroupLabels": [
+  "Placebo qw"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  "primaryOutcomes": [
+  {
+  "measure": "Percentage of Participants With a Positive Response (≥4-Fold Increase) to Tetanus Toxoid (the Adacel [Tdap] Vaccine) at Week 16",
+  "description": "A positive response was defined as a ≥ 4-fold increase from pre-vaccination at baseline in anti-tetanus immunoglobulin G (IgG) titer for participants with a pre-vaccination tetanus antibody titers ≥ 0.1 IU/ml or a titer of ≥ 0.2 IU/ml for participants with pre-vaccination titers of \\<0.1 IU/ml. There was no planned statistical hypothesis testing regarding the difference in immune response between the 2 treatment groups for this study, therefore no formal statistical hypothesis between groups was performed.",
+  "timeFrame": "Week 16"
+  }
+  ],
+  "secondaryOutcomes": [
+  {
+  "measure": "Percentage of Participants With a Positive Response (≥2-Fold Increase) to Tetanus Toxoid (the Adacel [Tdap] Vaccine) at Week 16",
+  "description": "Participants with positive response defined as a ≥2-fold increase from pre-vaccination baseline in anti-tetanus IgG titer for participants with pre-vaccination tetanus antibody titers ≥0.1 IU/ml or a titer of ≥0.2 IU/ml for participants with pre-vaccination titers of \\<0.1 IU/ml.",
+  "timeFrame": "Week 16"
+  },
+  {
+  "measure": "Percentage of Participants With a Positive Response (SBA Antibody Titer of ≥8 for Serogroup C) to Menomune Vaccine at Week 16",
+  "description": "A positive response to the Menomune vaccine was a serum bactericidal antibody (SBA) titer of ≥8 for serogroup C.",
+  "timeFrame": "Week 16"
+  },
+  {
+  "measure": "Percentage of Participants Achieving an Investigator's Global Assessment (IGA) Score of \"0\" or \"1\" at Week 16",
+  "description": "IGA was an assessment scale used to determine severity of AD and clinical response to treatment on a 5-point scale (0 = clear; 1 = almost clear; 2 = mild; 3 = moderate; 4 = severe) based on erythema and papulation/infiltration. Therapeutic response was an IGA score of 0 (clear) or 1 (almost clear). Values after first rescue treatment were set to missing and participants with missing IGA scores at Week 16 were counted as non-responders.",
+  "timeFrame": "Week 16"
+  },
+  {
+  "measure": "Percentage of Participants Achieving an Eczema Area and Severity Index-50 (EASI-50) (≥50% Improvement From Baseline) at Week 16",
+  "description": "The EASI score was used to measure the severity and extent of atopic dermatitis (AD) and measures erythema, infiltration, excoriation and lichenification on 4 anatomic regions of the body: head, trunk, upper and lower extremities. The total EASI score ranges from 0 (minimum) to 72 (maximum) points, with the higher scores reflecting the worse severity of AD. EASI-50 responders were the participants who achieved ≥50% overall improvement in EASI score from baseline to Week 16. Values after first rescue treatment were set to missing and participants with missing EASI score at Week 16 were counted as non-responders.",
+  "timeFrame": "Week 16"
+  },
+  {
+  "measure": "Percentage of Participants Achieving an Eczema Area and Severity Index-75 (EASI-75) (≥75% Improvement From Baseline) at Week 16",
+  "description": "The EASI score was used to measure the severity and extent of atopic dermatitis (AD) and measures erythema, infiltration, excoriation and lichenification on 4 anatomic regions of the body: head, trunk, upper and lower extremities. The total EASI score ranges from 0 (minimum) to 72 (maximum) points, with the higher scores reflecting the worse severity of AD. EASI-75 responders were the participants who achieved ≥75% overall improvement in EASI score from baseline to Week 16. Values after first rescue treatment use were set to missing and participants with missing EASI score at Week 16 were considered as non-responders.",
+  "timeFrame": "Week 16"
+  },
+  {
+  "measure": "Change From Baseline in Peak Weekly Averaged Pruritis Numerical Rating Scale (NRS) Scores at Week 16",
+  "description": "Pruritus NRS was an assessment tool that was used to report the intensity of participant's pruritus (itch), both maximum and average intensity, during a 24-hour recall period. Participants were asked the following question: how would a participant rate his itch at the worst moment during the previous 24 hours (for maximum itch intensity on a scale of 0 - 10 \\[0 = no itch; 10 = worst itch imaginable\\]). Weekly average obtained in the 7-day period prior to the baseline visit. Values after first rescue medication use were set to missing and missing values were imputed by Last observation carried forward (LOCF).",
+  "timeFrame": "Baseline to Week 16"
+  },
+  {
+  "measure": "Change From Baseline in Body Surface Area (BSA) Affected by AD at Week 16",
+  "description": "BSA affected by AD was assessed for each section of the body (the possible highest score for each region was: head and neck \\[9%\\], anterior trunk \\[18%\\], back \\[18%\\], upper limbs \\[18%\\], lower limbs \\[36%\\], and genitals \\[1%\\]). It was reported as a percentage of all major body sections combined. Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "timeFrame": "Baseline to Week 16"
+  },
+  {
+  "measure": "Change From Baseline in Global Individual Signs Score (GISS) Components (Erythema, Infiltration/Papulation, Excoriations and Lichenification) at Week 16",
+  "description": "Individual components of the AD lesions (erythema, infiltration/papulation, excoriations, and lichenification) were rated globally (each assessed for the whole body, not by anatomical region) on a 4-point scale (0 = none, 1 = mild, 2 = moderate and 3 = severe) using the EASI severity grading criteria. Total score ranges from 0 (absent disease) to 12 (severe disease). Values after first rescue treatment were set to missing. Analysis was completed using MMRM model which includes treatment, randomization strata, visit, baseline value, treatment-by-visit interaction, and baseline-by-visit interaction as covariates. These results are observed results without imputation.",
+  "timeFrame": "Baseline to Week 16"
+  },
+  {
+  "measure": "Changes From Baseline in GISS Cumulative Score to Week 16",
+  "description": "Individual components of the AD lesions (erythema, infiltration/papulation, excoriations, and lichenification) were rated globally (each assessed for the whole body, not by anatomical region) on a 4-point scale (0 = none, 1 = mild, 2 = moderate and 3 = severe) using the EASI severity grading criteria. Total score ranges from 0 (absent disease) to 12 (severe disease). Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "timeFrame": "Baseline to Week 16"
+  },
+  {
+  "measure": "Change in Patient Oriented Eczema Measure (POEM) Score From Baseline to Week 16",
+  "description": "The POEM was a 7-item questionnaire that assesses disease symptoms (dryness, itching, flaking, cracking, sleep loss, bleeding and weeping) with a scoring system of 0 (absent disease) to 28 (severe disease) (high score indicative of poor quality of life \\[QOL\\]). Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "timeFrame": "Baseline to Week 16"
+  }
+  ]
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Key Inclusion Criteria:\n\n1. Male or female adults ages 18 to 64 years with Chronic AD (according to the American Academy of Dermatology Consensus Criteria, \\[Eichenfeld 2004\\])that has been present for at least 3 years before the screening visit\n2. Participants with documented recent history (within 6 months before the screening visit) of inadequate response to a sufficient course of outpatient treatment with topical AD medication(s), or for whom topical AD therapies are otherwise inadvisable (e.g., because of side effects or safety risks).\n3. Eczema Area and Severity Index (EASI) score ≥16 at the screening visit and the baseline visit\n4. Investigator's Global Assessment (IGA) score ≥3 (on the 0-4 IGA scale) at the screening and baseline visits\n5. ≥10% body surface area (BSA) of AD involvement at the screening and baseline visits\n\nKey Exclusion Criteria:\n\n1. Prior treatment with dupilumab (REGN668/ SAR231893)\n2. Patients needing \\>10 mg of daily prednisone (including equivalent doses of other steroids) or high dose systemic corticosteroids (≥2 mg/kg) for 14 days or longer during the 16 week treatment period of the study\n3. History of Guillain-Barre syndrome\n4. History of severe allergic reaction to either vaccine or to vaccine components including alum, thimerosal, phenol\n5. Patients with a severe reaction to natural rubber latex products (some packaging components of the vaccines contain rubber latex and may cause a reaction in susceptible individuals)\n6. Treatment with biologics within 4 months of baseline visit\n7. Chronic or acute infection requiring treatment with antibiotics, antivirals, antiparasitics, antifungals within 4 weeks before screening visit or superficial skin infections within 1 week of screening visit\n\nThe information listed above is not intended to contain all considerations relevant to a patient's potential participation in a clinical trial and not all inclusion/ exclusion criteria are listed.",
+  "healthyVolunteers": false,
+  "sex": "ALL",
+  "minimumAge": "18 Years",
+  "maximumAge": "64 Years",
+  "stdAges": [
+  "ADULT"
+  ]
+  },
+  "contactsLocationsModule": {
+  "overallOfficials": [
+  {
+  "name": "Clinical Trial Management",
+  "affiliation": "Regeneron Pharmaceuticals",
+  "role": "STUDY_DIRECTOR"
+  }
+  ],
+  "locations": [
+  {
+  "city": "Birmingham",
+  "state": "Alabama",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 33.52066,
+  "lon": -86.80249
+  }
+  },
+  {
+  "city": "Fort Smith",
+  "state": "Arkansas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 35.38592,
+  "lon": -94.39855
+  }
+  },
+  {
+  "city": "Long Beach",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 33.76696,
+  "lon": -118.18923
+  }
+  },
+  {
+  "city": "Los Angeles",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 34.05223,
+  "lon": -118.24368
+  }
+  },
+  {
+  "city": "Mission Viejo",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 33.60002,
+  "lon": -117.672
+  }
+  },
+  {
+  "city": "Rolling Hills Estates",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 33.78779,
+  "lon": -118.35813
+  }
+  },
+  {
+  "city": "San Diego",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 32.71533,
+  "lon": -117.15726
+  }
+  },
+  {
+  "city": "Santa Monica",
+  "state": "California",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 34.01945,
+  "lon": -118.49119
+  }
+  },
+  {
+  "city": "Denver",
+  "state": "Colorado",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 39.73915,
+  "lon": -104.9847
+  }
+  },
+  {
+  "city": "Jacksonville",
+  "state": "Florida",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 30.33218,
+  "lon": -81.65565
+  }
+  },
+  {
+  "city": "Miami",
+  "state": "Florida",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 25.77427,
+  "lon": -80.19366
+  }
+  },
+  {
+  "city": "Tampa",
+  "state": "Florida",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 27.94752,
+  "lon": -82.45843
+  }
+  },
+  {
+  "city": "Macon",
+  "state": "Georgia",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 32.84069,
+  "lon": -83.6324
+  }
+  },
+  {
+  "city": "Chicago",
+  "state": "Illinois",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 41.85003,
+  "lon": -87.65005
+  }
+  },
+  {
+  "city": "Maywood",
+  "state": "Illinois",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 41.8792,
+  "lon": -87.84312
+  }
+  },
+  {
+  "city": "West Dundee",
+  "state": "Illinois",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.09808,
+  "lon": -88.28286
+  }
+  },
+  {
+  "city": "Indianapolis",
+  "state": "Indiana",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 39.76838,
+  "lon": -86.15804
+  }
+  },
+  {
+  "city": "Plainfield",
+  "state": "Indiana",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 39.70421,
+  "lon": -86.39944
+  }
+  },
+  {
+  "city": "Overland Park",
+  "state": "Kansas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 38.98223,
+  "lon": -94.67079
+  }
+  },
+  {
+  "city": "Boston",
+  "state": "Massachusetts",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.35843,
+  "lon": -71.05977
+  }
+  },
+  {
+  "city": "Ann Arbor",
+  "state": "Michigan",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.27756,
+  "lon": -83.74088
+  }
+  },
+  {
+  "city": "Troy",
+  "state": "Michigan",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.60559,
+  "lon": -83.14993
+  }
+  },
+  {
+  "city": "Saint Louis",
+  "state": "Missouri",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 38.62727,
+  "lon": -90.19789
+  }
+  },
+  {
+  "city": "Hackensack",
+  "state": "New Jersey",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 40.88593,
+  "lon": -74.04347
+  }
+  },
+  {
+  "city": "Albuquerque",
+  "state": "New Mexico",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 35.08449,
+  "lon": -106.65114
+  }
+  },
+  {
+  "city": "Buffalo",
+  "state": "New York",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.88645,
+  "lon": -78.87837
+  }
+  },
+  {
+  "city": "Forest Hills",
+  "state": "New York",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 40.71621,
+  "lon": -73.85014
+  }
+  },
+  {
+  "city": "New York",
+  "state": "New York",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 40.71427,
+  "lon": -74.00597
+  }
+  },
+  {
+  "city": "Cleveland",
+  "state": "Ohio",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 41.4995,
+  "lon": -81.69541
+  }
+  },
+  {
+  "city": "Norman",
+  "state": "Oklahoma",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 35.22257,
+  "lon": -97.43948
+  }
+  },
+  {
+  "city": "Tulsa",
+  "state": "Oklahoma",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 36.15398,
+  "lon": -95.99277
+  }
+  },
+  {
+  "city": "Medford",
+  "state": "Oregon",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 42.32652,
+  "lon": -122.87559
+  }
+  },
+  {
+  "city": "Portland",
+  "state": "Oregon",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 45.52345,
+  "lon": -122.67621
+  }
+  },
+  {
+  "city": "Pittsburgh",
+  "state": "Pennsylvania",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 40.44062,
+  "lon": -79.99589
+  }
+  },
+  {
+  "city": "Charleston",
+  "state": "South Carolina",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 32.77657,
+  "lon": -79.93092
+  }
+  },
+  {
+  "city": "Greer",
+  "state": "South Carolina",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 34.93873,
+  "lon": -82.22706
+  }
+  },
+  {
+  "city": "Arlington",
+  "state": "Texas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 32.73569,
+  "lon": -97.10807
+  }
+  },
+  {
+  "city": "Austin",
+  "state": "Texas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 30.26715,
+  "lon": -97.74306
+  }
+  },
+  {
+  "city": "Houston",
+  "state": "Texas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 29.76328,
+  "lon": -95.36327
+  }
+  },
+  {
+  "city": "Webster",
+  "state": "Texas",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 29.53773,
+  "lon": -95.11826
+  }
+  },
+  {
+  "city": "Richmond",
+  "state": "Virginia",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 37.55376,
+  "lon": -77.46026
+  }
+  },
+  {
+  "city": "Seattle",
+  "state": "Washington",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 47.60621,
+  "lon": -122.33207
+  }
+  }
+  ]
+  }
+  },
+  "resultsSection": {
+  "participantFlowModule": {
+  "preAssignmentDetails": "Out of 243 participants, 194 were randomized and treated in the study. Participants were randomized in 1:1 ratio to receive 600 mg subcutaneous (SC) dupilumab loading dose on day 1 and then dupilumab 300 mg once weekly (qw) or placebo qw.",
+  "recruitmentDetails": "The study was conducted at approximately 50 study sites in United States (US) between 05 August 2014 and 15 September 2015. A total of 243 participants were screened in the study.",
+  "groups": [
+  {
+  "id": "FG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "FG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "periods": [
+  {
+  "title": "Overall Study",
+  "milestones": [
+  {
+  "type": "STARTED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "97"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "97"
+  }
+  ]
+  },
+  {
+  "type": "COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "92"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "89"
+  }
+  ]
+  },
+  {
+  "type": "NOT COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "5"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "8"
+  }
+  ]
+  }
+  ],
+  "dropWithdraws": [
+  {
+  "type": "Adverse Event",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "0"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "5"
+  }
+  ]
+  },
+  {
+  "type": "Lost to Follow-up",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "2"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  },
+  {
+  "type": "Withdrawal by Subject",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  },
+  {
+  "type": "Physician Decision",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "0"
+  }
+  ]
+  },
+  {
+  "type": "Protocol Violation",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "0"
+  }
+  ]
+  },
+  {
+  "type": "Other than specified above",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "0"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "baselineCharacteristicsModule": {
+  "populationDescription": "The safety analysis set (SAF) included all randomized participants who received any study drug, and was analyzed as treated. Any participant given at least 1 dupilumab injection was assigned to the dupilumab group. The safety analysis was based on the SAF.",
+  "groups": [
+  {
+  "id": "BG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "BG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "BG002",
+  "title": "Total",
+  "description": "Total of all reporting groups"
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "measures": [
+  {
+  "title": "Age, Continuous",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "years",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "39.9",
+  "spread": "14.04"
+  },
+  {
+  "groupId": "BG001",
+  "value": "39.2",
+  "spread": "13.55"
+  },
+  {
+  "groupId": "BG002",
+  "value": "39.6",
+  "spread": "13.77"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Sex: Female, Male",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Female",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "51"
+  },
+  {
+  "groupId": "BG001",
+  "value": "48"
+  },
+  {
+  "groupId": "BG002",
+  "value": "99"
+  }
+  ]
+  },
+  {
+  "title": "Male",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "46"
+  },
+  {
+  "groupId": "BG001",
+  "value": "49"
+  },
+  {
+  "groupId": "BG002",
+  "value": "95"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Ethnicity (NIH/OMB)",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "13"
+  },
+  {
+  "groupId": "BG001",
+  "value": "15"
+  },
+  {
+  "groupId": "BG002",
+  "value": "28"
+  }
+  ]
+  },
+  {
+  "title": "Not Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "84"
+  },
+  {
+  "groupId": "BG001",
+  "value": "81"
+  },
+  {
+  "groupId": "BG002",
+  "value": "165"
+  }
+  ]
+  },
+  {
+  "title": "Unknown or Not Reported",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Race/Ethnicity, Customized",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "title": "White",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "67"
+  },
+  {
+  "groupId": "BG001",
+  "value": "60"
+  },
+  {
+  "groupId": "BG002",
+  "value": "127"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Black or African American",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "17"
+  },
+  {
+  "groupId": "BG001",
+  "value": "23"
+  },
+  {
+  "groupId": "BG002",
+  "value": "40"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Asian",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "11"
+  },
+  {
+  "groupId": "BG001",
+  "value": "12"
+  },
+  {
+  "groupId": "BG002",
+  "value": "23"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "American Indian or Alaska Native",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Other",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "2"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Anti-tetanus Immunoglobulin G (IgG) Titer",
+  "description": "Immune responses to vaccines included anti-tetanus IgG (Adacel \\[Tdap\\] vaccine) titre: A ≥ 2-fold or ≥ 4-fold increase from pre-vaccination at baseline in IgG titer for participants with a pre-vaccination tetanus antibody titers ≥ 0.1 IU/ml or a titer of ≥ 0.2 IU/ml for participants with pre-vaccination titers of \\<0.1 IU/ml.",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "IU/mL",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1.74",
+  "spread": "1.908"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1.51",
+  "spread": "1.328"
+  },
+  {
+  "groupId": "BG002",
+  "value": "1.62",
+  "spread": "1.644"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Eczema Area and Severity Index (EASI) Score",
+  "description": "The EASI score was used to measure the severity and extent of atopic dermatitis (AD) and measures erythema, infiltration, excoriation and lichenification on 4 anatomic regions of the body: head, trunk, upper and lower extremities. The total EASI score ranges from 0 (minimum) to 72 (maximum) points, with the higher scores reflecting the worse severity of AD.",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "units on a scale",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "31.23",
+  "spread": "13.771"
+  },
+  {
+  "groupId": "BG001",
+  "value": "29.04",
+  "spread": "13.085"
+  },
+  {
+  "groupId": "BG002",
+  "value": "30.14",
+  "spread": "13.442"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Investigator Global Assessment (IGA) Score",
+  "description": "IGA was an assessment scale used to determine severity of AD and clinical response to treatment on a 5-point scale (0 = clear; 1 = almost clear; 2 = mild; 3 = moderate; 4 = severe) based on erythema and papulation/infiltration. Therapeutic response was an IGA score of 0 (clear) or 1 (almost clear).",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "units on a scale",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "3.4",
+  "spread": "0.49"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3.4",
+  "spread": "0.49"
+  },
+  {
+  "groupId": "BG002",
+  "value": "3.4",
+  "spread": "0.49"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Weekly Peak Pruritus Numeric Rating Scale (NRS)",
+  "populationDescription": "Pruritus NRS was a tool used to report intensity of participant's pruritus (itch)--max \\& average intensity. Participants were asked: how would you rate the itch at worst moment during previous 24 hrs (max itch intensity, scale of 0-10 \\[0=no itch;10=worst itch imaginable\\]). Participants were excluded if baseline values were missed.",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "Units on a Scale",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "90"
+  },
+  {
+  "groupId": "BG001",
+  "value": "94"
+  },
+  {
+  "groupId": "BG002",
+  "value": "184"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "7.3",
+  "spread": "2.19"
+  },
+  {
+  "groupId": "BG001",
+  "value": "7.4",
+  "spread": "2.20"
+  },
+  {
+  "groupId": "BG002",
+  "value": "7.3",
+  "spread": "2.19"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Global Individual Signs Score (GISS) Total Score",
+  "description": "Individual components of the AD lesions (erythema,infiltration/papulation, excoriations, and lichenification) were rated globally (each assessed for the whole body, not by anatomical region) on a 4-point scale (0 = none, 1 = mild, 2 = moderate and 3 = severe) using the EASI severity grading criteria. Total score ranges from 0 (absent disease) to 12 (severe disease).",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "units on a scale",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "8.8",
+  "spread": "1.80"
+  },
+  {
+  "groupId": "BG001",
+  "value": "8.8",
+  "spread": "1.76"
+  },
+  {
+  "groupId": "BG002",
+  "value": "8.8",
+  "spread": "1.78"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Patient Oriented Eczema Measure (POEM) Score",
+  "description": "The POEM was a 7-item questionnaire that assessed disease symptoms (dryness, itching, flaking, cracking, sleep loss, bleeding and weeping) with a scoring system of 0 (absent disease) to 28 (severe disease) (high score indicative of poor quality of life \\[QOL\\]).",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "units on a scale",
+  "classes": [
+  {
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "97"
+  },
+  {
+  "groupId": "BG001",
+  "value": "97"
+  },
+  {
+  "groupId": "BG002",
+  "value": "194"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "20.6",
+  "spread": "5.59"
+  },
+  {
+  "groupId": "BG001",
+  "value": "21.5",
+  "spread": "6.04"
+  },
+  {
+  "groupId": "BG002",
+  "value": "21.1",
+  "spread": "5.82"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "outcomeMeasuresModule": {
+  "outcomeMeasures": [
+  {
+  "type": "PRIMARY",
+  "title": "Percentage of Participants With a Positive Response (≥4-Fold Increase) to Tetanus Toxoid (the Adacel [Tdap] Vaccine) at Week 16",
+  "description": "A positive response was defined as a ≥ 4-fold increase from pre-vaccination at baseline in anti-tetanus immunoglobulin G (IgG) titer for participants with a pre-vaccination tetanus antibody titers ≥ 0.1 IU/ml or a titer of ≥ 0.2 IU/ml for participants with pre-vaccination titers of \\<0.1 IU/ml. There was no planned statistical hypothesis testing regarding the difference in immune response between the 2 treatment groups for this study, therefore no formal statistical hypothesis between groups was performed.",
+  "populationDescription": "The immune response analysis set (IRS) included all randomized participants who received any study drug, vaccine injection at Week 12, and had 1 measurement for responses to tetanus toxoid vaccine at Week 16.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "92"
+  },
+  {
+  "groupId": "OG001",
+  "value": "90"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "83.7"
+  },
+  {
+  "groupId": "OG001",
+  "value": "83.3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants With a Positive Response (≥2-Fold Increase) to Tetanus Toxoid (the Adacel [Tdap] Vaccine) at Week 16",
+  "description": "Participants with positive response defined as a ≥2-fold increase from pre-vaccination baseline in anti-tetanus IgG titer for participants with pre-vaccination tetanus antibody titers ≥0.1 IU/ml or a titer of ≥0.2 IU/ml for participants with pre-vaccination titers of \\<0.1 IU/ml.",
+  "populationDescription": "The immune response analysis set (IRS) included all randomized participants who received any study drug, vaccine injection at Week 12, and had 1 measurement for responses to tetanus toxoid vaccine at Week 16.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "92"
+  },
+  {
+  "groupId": "OG001",
+  "value": "90"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "94.6"
+  },
+  {
+  "groupId": "OG001",
+  "value": "95.6"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants With a Positive Response (SBA Antibody Titer of ≥8 for Serogroup C) to Menomune Vaccine at Week 16",
+  "description": "A positive response to the Menomune vaccine was a serum bactericidal antibody (SBA) titer of ≥8 for serogroup C.",
+  "populationDescription": "The immune response analysis set (IRS) included all randomized participants who received any study drug, vaccine injection at Week 12, and had 1 measurement for responses to tetanus toxoid vaccine at Week 16.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "92"
+  },
+  {
+  "groupId": "OG001",
+  "value": "90"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "87.0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "86.7"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants Achieving an Investigator's Global Assessment (IGA) Score of \"0\" or \"1\" at Week 16",
+  "description": "IGA was an assessment scale used to determine severity of AD and clinical response to treatment on a 5-point scale (0 = clear; 1 = almost clear; 2 = mild; 3 = moderate; 4 = severe) based on erythema and papulation/infiltration. Therapeutic response was an IGA score of 0 (clear) or 1 (almost clear). Values after first rescue treatment were set to missing and participants with missing IGA scores at Week 16 were counted as non-responders.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "10.3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "44.3"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using Cochran-Mantel-Haenszel test stratified by randomization strata (moderate \\[IGA=3\\] vs. severe \\[IGA=4\\] AD).",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "Cochran-Mantel-Haenszel",
+  "paramType": "Percentage Difference",
+  "paramValue": "34.0",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "24.29",
+  "ciUpperLimit": "43.75",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants Achieving an Eczema Area and Severity Index-50 (EASI-50) (≥50% Improvement From Baseline) at Week 16",
+  "description": "The EASI score was used to measure the severity and extent of atopic dermatitis (AD) and measures erythema, infiltration, excoriation and lichenification on 4 anatomic regions of the body: head, trunk, upper and lower extremities. The total EASI score ranges from 0 (minimum) to 72 (maximum) points, with the higher scores reflecting the worse severity of AD. EASI-50 responders were the participants who achieved ≥50% overall improvement in EASI score from baseline to Week 16. Values after first rescue treatment were set to missing and participants with missing EASI score at Week 16 were counted as non-responders.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "32.0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "72.2"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using Cochran-Mantel-Haenszel test stratified by randomization strata (moderate \\[IGA=3\\] vs. severe \\[IGA=4\\] AD).",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "Cochran-Mantel-Haenszel",
+  "paramType": "Percentage Difference",
+  "paramValue": "40.2",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "29.40",
+  "ciUpperLimit": "51.01",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants Achieving an Eczema Area and Severity Index-75 (EASI-75) (≥75% Improvement From Baseline) at Week 16",
+  "description": "The EASI score was used to measure the severity and extent of atopic dermatitis (AD) and measures erythema, infiltration, excoriation and lichenification on 4 anatomic regions of the body: head, trunk, upper and lower extremities. The total EASI score ranges from 0 (minimum) to 72 (maximum) points, with the higher scores reflecting the worse severity of AD. EASI-75 responders were the participants who achieved ≥75% overall improvement in EASI score from baseline to Week 16. Values after first rescue treatment use were set to missing and participants with missing EASI score at Week 16 were considered as non-responders.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "Percentage of participants",
+  "timeFrame": "Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "19.6"
+  },
+  {
+  "groupId": "OG001",
+  "value": "53.6"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using Cochran-Mantel-Haenszel test stratified by randomization strata (moderate \\[IGA=3\\] vs. severe \\[IGA=4\\] AD).",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "Cochran-Mantel-Haenszel",
+  "paramType": "Percentage Difference",
+  "paramValue": "34.0",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "23.38",
+  "ciUpperLimit": "44.66",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Peak Weekly Averaged Pruritis Numerical Rating Scale (NRS) Scores at Week 16",
+  "description": "Pruritus NRS was an assessment tool that was used to report the intensity of participant's pruritus (itch), both maximum and average intensity, during a 24-hour recall period. Participants were asked the following question: how would a participant rate his itch at the worst moment during the previous 24 hours (for maximum itch intensity on a scale of 0 - 10 \\[0 = no itch; 10 = worst itch imaginable\\]). Weekly average obtained in the 7-day period prior to the baseline visit. Values after first rescue medication use were set to missing and missing values were imputed by Last observation carried forward (LOCF).",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants. Here, number of participants analyzed=participants with available data for this endpoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "Units on a scale",
+  "timeFrame": "Baseline to Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "90"
+  },
+  {
+  "groupId": "OG001",
+  "value": "94"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-2.11",
+  "spread": "0.259"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-4.24",
+  "spread": "0.250"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using ANCOVA model which includes treatment, randomization strata, and baseline value as covariates.",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "ANCOVA",
+  "paramType": "LS Mean Difference",
+  "paramValue": "-2.13",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.72",
+  "ciUpperLimit": "-1.55",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.354",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Body Surface Area (BSA) Affected by AD at Week 16",
+  "description": "BSA affected by AD was assessed for each section of the body (the possible highest score for each region was: head and neck \\[9%\\], anterior trunk \\[18%\\], back \\[18%\\], upper limbs \\[18%\\], lower limbs \\[36%\\], and genitals \\[1%\\]). It was reported as a percentage of all major body sections combined. Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants. Here, number of participants analyzed=participants with available data for this endpoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "Percentage of BSA",
+  "timeFrame": "Baseline to Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-11.0",
+  "spread": "2.11"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-28.7",
+  "spread": "2.00"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using ANCOVA model that includes treatment, randomization strata and baseline value as covariates.",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "ANCOVA",
+  "paramType": "LS Mean Difference",
+  "paramValue": "-17.8",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-22.5",
+  "ciUpperLimit": "-13.1",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.84",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Global Individual Signs Score (GISS) Components (Erythema, Infiltration/Papulation, Excoriations and Lichenification) at Week 16",
+  "description": "Individual components of the AD lesions (erythema, infiltration/papulation, excoriations, and lichenification) were rated globally (each assessed for the whole body, not by anatomical region) on a 4-point scale (0 = none, 1 = mild, 2 = moderate and 3 = severe) using the EASI severity grading criteria. Total score ranges from 0 (absent disease) to 12 (severe disease). Values after first rescue treatment were set to missing. Analysis was completed using MMRM model which includes treatment, randomization strata, visit, baseline value, treatment-by-visit interaction, and baseline-by-visit interaction as covariates. These results are observed results without imputation.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants. Here, number of participants analyzed=participants with available data for this endpoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "Units on a scale",
+  "timeFrame": "Baseline to Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Erythema",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "79"
+  },
+  {
+  "groupId": "OG001",
+  "value": "87"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.4",
+  "spread": "0.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.9",
+  "spread": "0.08"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Infiltration/Papulation",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "79"
+  },
+  {
+  "groupId": "OG001",
+  "value": "87"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.4",
+  "spread": "0.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.1",
+  "spread": "0.08"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Excoriations",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "79"
+  },
+  {
+  "groupId": "OG001",
+  "value": "87"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.5",
+  "spread": "0.09"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.2",
+  "spread": "0.08"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Lichenification",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "79"
+  },
+  {
+  "groupId": "OG001",
+  "value": "87"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.4",
+  "spread": "0.09"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.0",
+  "spread": "0.09"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Changes From Baseline in GISS Cumulative Score to Week 16",
+  "description": "Individual components of the AD lesions (erythema, infiltration/papulation, excoriations, and lichenification) were rated globally (each assessed for the whole body, not by anatomical region) on a 4-point scale (0 = none, 1 = mild, 2 = moderate and 3 = severe) using the EASI severity grading criteria. Total score ranges from 0 (absent disease) to 12 (severe disease). Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants. Here, number of participants analyzed=participants with available data for this endpoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "Units on a scale",
+  "timeFrame": "Baseline to Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.7",
+  "spread": "0.28"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-4.1",
+  "spread": "0.28"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using the ANCOVA model which includes treatment, randomization strata, and baseline values as covariates.",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "ANCOVA",
+  "paramType": "LS Mean Difference",
+  "paramValue": "-2.4",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-3.0",
+  "ciUpperLimit": "-1.7",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.39",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change in Patient Oriented Eczema Measure (POEM) Score From Baseline to Week 16",
+  "description": "The POEM was a 7-item questionnaire that assesses disease symptoms (dryness, itching, flaking, cracking, sleep loss, bleeding and weeping) with a scoring system of 0 (absent disease) to 28 (severe disease) (high score indicative of poor quality of life \\[QOL\\]). Values after first rescue medication use were set to missing and missing values were imputed by LOCF.",
+  "populationDescription": "Full analysis set (FAS) that included all randomized participants. Here, number of participants analyzed=participants with available data for this endpoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "Units on a Scale",
+  "timeFrame": "Baseline to Week 16",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15."
+  },
+  {
+  "id": "OG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "97"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-4.8",
+  "spread": "0.72"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-13.1",
+  "spread": "0.70"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Analysis was performed using the ANCOVA model which included treatment, randomization strata, and baseline value as covariates.",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "<0.0001",
+  "statisticalMethod": "ANCOVA",
+  "paramType": "LS Mean Difference",
+  "paramValue": "-8.3",
+  "ciPctValue": "90",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-9.9",
+  "ciUpperLimit": "-6.6",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.99",
+  "estimateComment": "Dupilumab 300 mg qw vs. Placebo qw"
+  }
+  ]
+  }
+  ]
+  },
+  "adverseEventsModule": {
+  "frequencyThreshold": "5",
+  "timeFrame": "Adverse Events (AE) were collected from signature of the informed consent form up to the final visit (Week 32) regardless of seriousness or relationship to investigational product",
+  "description": "Reported AEs are treatment-emergent adverse events which are AEs that developed/worsened during the 'on treatment period' (from the administration of first dose of study drug up to the final visit \\[Week 32\\]).",
+  "eventGroups": [
+  {
+  "id": "EG000",
+  "title": "Placebo qw",
+  "description": "Two subcutaneous injections of Placebo (for Dupilumab) as a loading dose on Day 1 followed by a single injection qw from Week 1 to Week 15.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 97,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 97,
+  "otherNumAffected": 29,
+  "otherNumAtRisk": 97
+  },
+  {
+  "id": "EG001",
+  "title": "Dupilumab 300 mg qw",
+  "description": "Two subcutaneous injections of Dupilumab 300 mg (for a total of 600 mg) as a loading dose on Day 1, followed by a single 300 mg injection qw from Week 1 to Week 15.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 97,
+  "seriousNumAffected": 3,
+  "seriousNumAtRisk": 97,
+  "otherNumAffected": 30,
+  "otherNumAtRisk": 97
+  }
+  ],
+  "seriousEvents": [
+  {
+  "term": "Serum sickness-like reaction",
+  "organSystem": "Immune system disorders",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Mycosis fungoides stage iv",
+  "organSystem": "Neoplasms benign, malignant and unspecified (incl cysts and polyps)",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Squamous cell carcinoma",
+  "organSystem": "Neoplasms benign, malignant and unspecified (incl cysts and polyps)",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 97
+  }
+  ]
+  }
+  ],
+  "otherEvents": [
+  {
+  "term": "Injection site reaction",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 5,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Conjunctivitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 8,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Nasopharyngitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 5,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 4,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Upper respiratory tract infection",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 14,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 11,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Headache",
+  "organSystem": "Nervous system disorders",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 3,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 5,
+  "numAtRisk": 97
+  }
+  ]
+  },
+  {
+  "term": "Dermatitis atopic",
+  "organSystem": "Skin and subcutaneous tissue disorders",
+  "sourceVocabulary": "MedDRA (18.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 11,
+  "numAtRisk": 97
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 97
+  }
+  ]
+  }
+  ]
+  },
+  "moreInfoModule": {
+  "certainAgreement": {
+  "piSponsorEmployee": false,
+  "restrictionType": "OTHER",
+  "restrictiveAgreement": true,
+  "otherDetails": "The investigator has the right to independently publish study results from the investigator's site after a multi-center publication, or a defined period after the completion of the study by all sites. The investigator must provide the sponsor a copy of any such publication derived from the study for review and comment in advance of any submission, and delay publication, if requested, to allow the Sponsor to preserve its proprietary rights."
+  },
+  "pointOfContact": {
+  "title": "Clinical Trial Management",
+  "organization": "Regeneron Pharmaceuticals, Inc.",
+  "email": "clinicaltrials@regeneron.com",
+  "phone": "844-734-6643"
+  }
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2023-11-15",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000003876",
+  "term": "Dermatitis, Atopic"
+  },
+  {
+  "id": "D000003872",
+  "term": "Dermatitis"
+  },
+  {
+  "id": "D000004485",
+  "term": "Eczema"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000012871",
+  "term": "Skin Diseases"
+  },
+  {
+  "id": "D000012873",
+  "term": "Skin Diseases, Genetic"
+  },
+  {
+  "id": "D000030342",
+  "term": "Genetic Diseases, Inborn"
+  },
+  {
+  "id": "D000017443",
+  "term": "Skin Diseases, Eczematous"
+  },
+  {
+  "id": "D000006969",
+  "term": "Hypersensitivity, Immediate"
+  },
+  {
+  "id": "D000006967",
+  "term": "Hypersensitivity"
+  },
+  {
+  "id": "D000007154",
+  "term": "Immune System Diseases"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M6761",
+  "name": "Dermatitis, Atopic",
+  "asFound": "Atopic Dermatitis",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M6757",
+  "name": "Dermatitis",
+  "asFound": "Dermatitis",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M7345",
+  "name": "Eczema",
+  "asFound": "Atopic Dermatitis",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M15364",
+  "name": "Skin Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M15366",
+  "name": "Skin Diseases, Genetic",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M23376",
+  "name": "Genetic Diseases, Inborn",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M19402",
+  "name": "Skin Diseases, Eczematous",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M9708",
+  "name": "Hypersensitivity",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M9710",
+  "name": "Hypersensitivity, Immediate",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M9890",
+  "name": "Immune System Diseases",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BC16",
+  "name": "Diseases and Abnormalities at or Before Birth"
+  },
+  {
+  "abbrev": "BC17",
+  "name": "Skin and Connective Tissue Diseases"
+  },
+  {
+  "abbrev": "BC20",
+  "name": "Immune System Diseases"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  }
+  ]
+  },
+  "interventionBrowseModule": {
+  "browseLeaves": [
+  {
+  "id": "M17050",
+  "name": "Vaccines",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "All",
+  "name": "All Drugs and Chemicals"
+  }
+  ]
+  }
+  },
+  "hasResults": true
+  }

--- a/spec/support/json_data/NCT03630471.json
+++ b/spec/support/json_data/NCT03630471.json
@@ -1,417 +1,417 @@
 {
-    "protocolSection": {
-    "identificationModule": {
-    "nctId": "NCT03630471",
-    "orgStudyIdInfo": {
-    "id": "SANPRIDE_002"
-    },
-    "organization": {
-    "fullName": "Sangath",
-    "class": "OTHER"
-    },
-    "briefTitle": "Effectiveness of a Problem-solving Intervention for Common Adolescent Mental Health Problems in India",
-    "officialTitle": "The Effectiveness of a Low-intensity, Lay Counsellor-delivered, Problem-solving Intervention for Common Mental Health Problems in School-going Adolescents in New Delhi, India: the PRIDE Study Protocol for a Randomized Controlled Trial",
-    "acronym": "PRIDE"
-    },
-    "statusModule": {
-    "statusVerifiedDate": "2019-01",
-    "overallStatus": "COMPLETED",
-    "expandedAccessInfo": {
-    "hasExpandedAccess": false
-    },
-    "startDateStruct": {
-    "date": "2018-08-20",
-    "type": "ACTUAL"
-    },
-    "primaryCompletionDateStruct": {
-    "date": "2019-01-20",
-    "type": "ACTUAL"
-    },
-    "completionDateStruct": {
-    "date": "2019-02-28",
-    "type": "ACTUAL"
-    },
-    "studyFirstSubmitDate": "2018-08-06",
-    "studyFirstSubmitQcDate": "2018-08-09",
-    "studyFirstPostDateStruct": {
-    "date": "2018-08-14",
-    "type": "ACTUAL"
-    },
-    "lastUpdateSubmitDate": "2019-05-17",
-    "lastUpdatePostDateStruct": {
-    "date": "2019-05-21",
-    "type": "ACTUAL"
-    }
-    },
-    "sponsorCollaboratorsModule": {
-    "responsibleParty": {
-    "type": "SPONSOR"
-    },
-    "leadSponsor": {
-    "name": "Sangath",
-    "class": "OTHER"
-    },
-    "collaborators": [
-    {
-    "name": "Harvard Medical School (HMS and HSDM)",
-    "class": "OTHER"
-    },
-    {
-    "name": "London School of Hygiene and Tropical Medicine",
-    "class": "OTHER"
-    }
-    ]
-    },
-    "oversightModule": {
-    "oversightHasDmc": true,
-    "isFdaRegulatedDrug": false,
-    "isFdaRegulatedDevice": false
-    },
-    "descriptionModule": {
-    "briefSummary": "We will conduct a two-arm individually randomized controlled trial in six Government-run secondary schools in New Delhi. The targeted sample is 240 adolescents in grades 9-12 with persistent, elevated mental health difficulties and associated impact. Participants will receive either a brief problem-solving intervention delivered by lay counsellors (intervention), or enhanced usual care comprised of problem-solving booklets (control). Self-reported adolescent mental health difficulties and idiographic problems will be assessed at 6 weeks (co-primary outcomes) and again at 12 weeks post-randomization. In addition, adolescent-reported impact of mental health difficulties, perceived stress, mental wellbeing and clinical remission, as well as parent-reported adolescent mental health difficulties and impact scores, will be assessed at 6 and 12 weeks post-randomization. Parallel process evaluation, including estimations of the costs of delivering the interventions, will be conducted.",
-    "detailedDescription": "Background and rationale:\n\nThis study is part of a larger research program called PRIDE (PRemIum for aDolEscents) for which the goals are to:\n\n* develop a trans-diagnostic, stepped-care intervention targeting common mental disorders in school-going adolescents in India; and\n* evaluate its effectiveness in reducing symptom severity and improving recovery rates among adolescent participants\n\nThe components of the stepped-care intervention will be evaluated in separate, linked studies. The main aim of the current trial is to evaluate the effectiveness of a low-intensity problem-solving intervention (the first step of the PRIDE stepped-care intervention) delivered by school counsellors for adolescents with common mental health problems, when compared with enhanced usual care (EUC).\n\nThe primary hypothesis is that the intervention will be superior to the EUC control condition in reducing the severity of self-reported mental health symptoms and prioritized problems at six weeks post-randomization.\n\nStudy design and setting:\n\nThis is a parallel-arm, individually randomized controlled trial with equal allocation of participants between arms. The trial will be conducted in six Government-run secondary schools (Grade 9 to 12; approximately corresponding to 13-20 years of age) from the National Capital Territory of Delhi, India. A process evaluation will be nested in the trial to provide findings that will assist in the interpretation of the trial results and to inform potential implementation of the PRIDE intervention on a wider scale.\n\nEligibility criteria: see 'Eligibility' section.\n\nInterventions: see 'Arms and Interventions' section.\n\nScreening measures: Referred adolescents will be screened for common mental health difficulties, impact and chronicity using the SDQ (Goodman et al., 2000), according to the eligibility criteria set out below.\n\nSociodemographic information: This will be obtained from all enrolled participants through an interviewer-administered questionnaire, with responses entered directly into a tablet computer.\n\nOutcome measures: see 'Outcome Measures' section.\n\nEconomic measures: The costs associated with the introduction of the experimental and control arm interventions will be estimated by adding the personnel costs for counsellors and supervisors, together with fixed costs of training (venue/per diem), furniture and supplies. All costs will be reported in Indian Rupees and then converted to US Dollars at the average daily exchange rate over the preceding 12 months.\n\nProcess measures:\n\nProcess data on enrollment, randomization and assessment procedures will be obtained from researcher-completed record forms. These will be collated to obtain assent/consent rates of adolescents and parents (and reasons for missing assent/consent); randomization rates (and reasons for randomization errors); completion rates of baseline and follow-up outcome assessments (and reasons for non-completion); and time lags between intended and completed assessments (and reasons for deviating from targets). In addition, motivations for help-seeking and expectancies for the school counselling program will be explored at the time of eligibility assessment through a brief qualitative interview with a sub-sample of referred students.\n\nIntervention processes will be assessed using additional data sources. Counsellor-completed session record forms will be used to obtain process data on duration, spacing and frequency of attended sessions (and reasons for non-attendance); and intervention uptake and completion rates (and reasons for pre-intervention and mid-intervention drop-out). Participants' adherence to treatment and potential engagement challenges will be assessed using checklists within the same record forms, indicating whether or not the student completed practice exercises at home, used the POD (Problems-Options-Do it yourself) booklets at home, brought the POD booklets to the session, and demonstrated understanding of POD booklets and session content. Use of POD booklets will be assessed in each arm of the trial at 6- and 12-week follow-up assessments using a brief adolescent-reported measure that asks about estimated frequency of home use and perceived helpfulness of POD booklets in the preceding 6 weeks. Service satisfaction data will also be obtained from participants in each trial arm at 12 weeks using the 8-item Client Satisfaction Questionnaire (CSQ-8) (Larsen et al., 1979). Supplementary questions will elicit open-ended written feedback on the most helpful aspects of the available intervention and suggested modifications.\n\nIntervention fidelity will be assessed using independent ratings of audio-recorded sessions: 10% of all recordings will be selected at random and rated by a psychologist who is not directly involved with supervision of the intervention providers.\n\nSample size:\n\nSample size estimations have been produced for two co-primary outcomes: mental health symptoms (SDQ Total Difficulties score) and idiographic problems (YTP score). A Bonferroni correction has been used to adjust for multiple primary outcomes. Following pilot work that indicated large (uncontrolled) effect sizes, the investigators have conservatively assumed that the intervention will be associated with an effect size of 0.5 (difference in means/SD) on both the primary outcomes with 90% power at 6 weeks post-randomization. The investigators have also assumed a loss to follow up of 15% over 6 weeks, based on pilot work. Based on these assumptions and a 1:1 allocation ratio for individual randomization, a total of 240 participants will be required. This sample size provides 80% power to detect an ES of 0.44.\n\nRecruitment methods and sampling frame:\n\nA combination of whole-school and classroom-based sensitization methods will be used to generate referrals into the trial. This will include posters, teacher briefings and classroom-based information sessions for students. Referrals may be initiated in a number of ways: (1) adolescents can directly approach a researcher following a classroom information session; (2) adolescents can provide their contact details in a 'drop box' placed in the school; or (3) adolescents can request a referral through a teacher (or a teacher may raise the prospect of referral directly with a student before initiating the same). Referred participants will be assessed for eligibility using the SDQ; those meeting eligibility criteria will be invited to participate in the trial. Referred adolescents who do not meet eligibility criteria will receive a handout on self-care strategies.\n\nIn the academic year 2018-19, there are 172 class divisions of grades 9-12 in the six collaborating schools in New Delhi, and approximately 50 students per class. Seventy classes will participate in an embedded recruitment trial (see separate protocol: NCT03633916). The host intervention trial will recruit participants originating from the 70 classes sampled in the embedded recruitment trial, as well as participants drawn from other classes as needed. The precise schedule of recruitment activities in the remaining 102 classes will be calibrated according to referral patterns and caseload capacity for intervention providers in the various schools.\n\nAssent/consent procedures:\n\nReferred adolescents will be invited to meet with a researcher when a 2-stage consent process will be initiated.\n\n1. Assent/consent for using screening data: All referred students who are screened for eligibility will be provided with written information and structured verbal information about the potential use of their screening data for evaluation of help-seeking patterns. Assent, consent will be obtained on signed consent forms.\n2. Assent/consent for trial participation: Eligible students will be provided with additional structured verbal information and a printed participant information sheet about trial participation. Assent will be sought for adolescents who are below 18 years of age, and consent will be sought for adolescents who are 18 years of age or older. For assenting participants aged below 18 years of age, consent from a parent/guardian will be sought by a researcher. This will involve two levels of consent: consent for their child to participate in the trial, and consent for a parent's/guardian's own participation in the study. The informed assent/consent procedure with adolescents will be completed during school hours, while the parent/guardian consent process will be completed at the family's home or another convenient location. Details of assenting/consenting adolescents and consenting parents (and those declining to participate) will be logged on an ongoing basis, along with reasons for non-participation.\n\nData collection procedures (see 'Outcome Measures' for detailed descriptions of measures referenced below):\n\nField researchers will administer outcome measures in schools, at home or other convenient locations. The adolescent-reported SDQ will be collected by a field researcher on a digital tablet device, and will also serve as the basis for eligibility screening. Other baseline assessments will be completed as soon as possible after assent/consent procedures are completed (and ideally on the same day). The YTP will be administered on paper while the remaining scales will be administered on a digital tablet device. The YTP will be administered on paper as it asks the participants to describe, prioritize and score their three main problems; the same list of problems will be rated again during follow-up assessments (see below). Adolescents will also be assessed on the PSS-4 and SWEMWBS. Index parents will be invited to complete the SDQ only. Sociodemographic data from the adolescent and parent/guardian will also be collected on digital tablets.\n\nFollow-up assessments will be completed at 6 and 12 weeks post-randomization. The 6-week outcome is the primary end-point, as the optimal effect of the intervention is expected to occur immediately after the intervention has been completed. The 12-week end-point is included to evaluate the durability of intervention effects. The CSQ-8 (a process measure of service satisfaction) will be collected at 12 weeks post-randomization only. Additionally, all adolescents will complete a self-report measure on the use of the intervention materials (problem-solving booklets) provided in the intervention and control arms.\n\nData analysis plan:\n\nDescriptive analyses: Initial analyses will compare baseline characteristics of referred adolescents who did and did were not enrolled into the trial for various reasons. Baseline characteristics of enrolled participants will be compared between trial arms. Findings will be reported as per the CONSORT guidelines, using intention-to-treat analysis, including a trial flow chart.\n\nOutcome measures will be summarized at recruitment, at 6- and 12-week follow up by trial arm, and overall. These will be summarized by means (standard deviation), medians (interquartile range), or numbers and proportions as appropriate. For continuous outcomes, histograms will also be plotted within each arm to assess how closely the scales follow a normal distribution. This will determine how the outcomes are described as well as the choice of inferential analysis method.\n\nOutcome analyses: The primary analyses will be on an intention-to-treat basis at the 6-week end-point, adjusted for baseline values of the outcome measure; school (as a fixed effect in the analysis) to allow for within-school clustering, counsellor variation (as a random effect); and variables for which randomization did not achieve reasonable balance between the arms at baseline, or those associated with missing outcome data. Intervention effects will be presented as adjusted mean differences and effect sizes (ES), defined as standardized mean differences.\n\nFor continuous variables, the analysis of secondary and exploratory outcomes will use similar methods to the primary outcome analysis for continuous variables. For the binary outcome (remission), the intervention effect will be reported as the adjusted odds ratio with 95% CIs. Generalized (linear or logistic) random-effects regression models will be used, adjusting for baseline outcome score and clustering, and other baseline variables as above. For outcomes to be examined over the 12-week follow-up period (other than remission), regression models will include a variable to represent 'time' in order to indicate whether the data were collected at the 6- or 12-week end-point. To assess whether the intervention effect varies over time, an intervention x time interaction term will be fitted to allow for a different intervention effect at 6 vs 12 months, although this will not be highly powered.\n\nWe will explore potential moderators of intervention effects, with respect to a priori defined modifiers (i.e. chronicity of mental health difficulties, severity of mental health difficulties, YTP type, SDQ caseness profile). We will fit relevant interaction terms and test for heterogeneity of intervention effects in regression models. A mediation analysis will be conducted to examine whether the theoretically-driven a priori factor (perceived stress at 6 weeks) mediates the effects of the intervention on primary outcomes (i.e. mental health symptoms and idiographic problems) at 12 weeks. Additionally, intervention effects for students who receive fewer sessions than prescribed will be estimated using the Complier Average Causal Effect structural equation model.\n\nProcess evaluation: We will undertake descriptive statistical analysis of quantitative process data in order to explore the implementation of intervention procedures. In addition, thematic analysis will be used to code and organise qualitative interview data on intervention expectancies (assessed prior to enrolment) and qualitative written feedback on service satisfaction (assessed at 12-week follow-up). Findings from the various data sources will be triangulated and used to develop explanatory hypotheses about potential differences in intervention delivery and engagement across schools, subgroups of participants and providers. Process evaluation findings will be used to facilitate interpretation of the main trial results. The trial statisticians may conduct further analyses to test hypotheses generated from integration of the process evaluation and trial outcome data.\n\nCost-effectiveness analysis: The costs associated with the introduction of the PRIDE and control arm interventions will be estimated by adding the fixed costs of materials and personnel costs."
-    },
-    "conditionsModule": {
-    "conditions": [
-    "Mental Health Issue (E.G., Depression, Psychosis, Personality Disorder, Substance Abuse)"
-    ],
-    "keywords": [
-    "Adolescents"
-    ]
-    },
-    "designModule": {
-    "studyType": "INTERVENTIONAL",
-    "phases": [
-    "NA"
-    ],
-    "designInfo": {
-    "allocation": "RANDOMIZED",
-    "interventionModel": "PARALLEL",
-    "interventionModelDescription": "A two-arm, individually randomized controlled trial with equal allocation of participants between arms.",
-    "primaryPurpose": "TREATMENT",
-    "maskingInfo": {
-    "masking": "DOUBLE",
-    "maskingDescription": "The randomization list will be generated by an independent statistician. The randomization code will be concealed using sequentially numbered opaque sealed envelopes to maximize allocation concealment.\n\nBaseline assessments will be carried out by field researchers prior to randomization. The six- and 12-week outcome assessments will be carried out by a team of field researchers who will be blind to allocation status.",
-    "whoMasked": [
-    "INVESTIGATOR",
-    "OUTCOMES_ASSESSOR"
-    ]
-    }
-    },
-    "enrollmentInfo": {
-    "count": 250,
-    "type": "ACTUAL"
-    }
-    },
-    "armsInterventionsModule": {
-    "armGroups": [
-    {
-    "label": "Control",
-    "type": "ACTIVE_COMPARATOR",
-    "description": "Enhanced usual care (problem-solving booklets only).",
-    "interventionNames": [
-    "Behavioral: Enhanced usual care"
-    ]
-    },
-    {
-    "label": "Intervention",
-    "type": "EXPERIMENTAL",
-    "description": "PRIDE 'Step 1' problem-solving intervention.",
-    "interventionNames": [
-    "Behavioral: PRIDE 'Step 1' problem-solving intervention"
-    ]
-    }
-    ],
-    "interventions": [
-    {
-    "type": "BEHAVIORAL",
-    "name": "PRIDE 'Step 1' problem-solving intervention",
-    "description": "The PRIDE problem-solving intervention is one component of the PRIDE stepped care treatment architecture which comprises two sequential treatments of incremental intensity. 'Step 1' is a brief, first-line treatment. It is grounded in stress-coping theory, with a technical focus on practical problem-solving to modify developmentally salient stressors.\n\nStep 1 has been designed as a 'low-intensity' intervention requiring fewer resources than conventional psychological treatments. This is achieved through a relatively brief delivery schedule (up to 5 x 20-30-minute sessions spread over approximately 3 weeks) and limited requirement for specialists. The delivery agents are lay counsellors receiving a combination of specialist and peer supervision. The counsellors offer guidance sessions to support the learning and implementation of problem-solving and complementary coping skills. Illustrated booklets are used to support learning of problem-solving concepts and skills practice at home.",
-    "armGroupLabels": [
-    "Intervention"
-    ]
-    },
-    {
-    "type": "BEHAVIORAL",
-    "name": "Enhanced usual care",
-    "description": "There is no established mental health service provision in the collaborating schools. The control arm participants will receive an enhancement of this 'usual care' (essentially, no care) by having access to the same illustrated booklets used in the Intervention arm, albeit without any counsellor contact.",
-    "armGroupLabels": [
-    "Control"
-    ]
-    }
-    ]
-    },
-    "outcomesModule": {
-    "primaryOutcomes": [
-    {
-    "measure": "Mental health symptoms",
-    "description": "The Strengths and Difficulties Questionnaire (SDQ) is a 25-item self-report measure of youth mental health symptoms (Goodman et al., 2000). A Total Difficulties score is derived by summing items from four problem subscales (Emotional, Conduct, Hyperactivity/inattention and Peer problems). The measure is the most widely used clinical and research instrument in the field of child and adolescent mental health globally. The Hindi version will be used in complementary forms for self-report by adolescents and parents. The adolescent-reported SDQ Total Difficulties score (at 6-week end-point) will be a co-primary outcome, while the corresponding caregiver-reported SDQ Total Difficulties score will be an exploratory outcome.",
-    "timeFrame": "6 weeks"
-    },
-    {
-    "measure": "Idiographic problems",
-    "description": "The Youth Top Problems (YTP) is a brief, idiographic measure which identifies, prioritizes and scores respondents' three main problems (Weisz et al., 2011). Each nominated problem is scored from 0 ('not a problem') to 10 ('huge problem'). A mean severity score is calculated by summing individual problem scores and then dividing by the number of nominated problems. The YTP will be used to assess problems that other scales might address generally or otherwise miss; while providing a sensitive measure of specific priorities of the participant within a larger array of problems.",
-    "timeFrame": "6 weeks"
-    }
-    ],
-    "secondaryOutcomes": [
-    {
-    "measure": "Mental health symptoms",
-    "description": "The adolescent-reported SDQ Total Difficulties score at 12 weeks will be a secondary outcome, while the corresponding caregiver-reported SDQ Total Difficulties score will be an exploratory outcome.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Idiographic problems",
-    "description": "The adolescent-reported YTP severity score at 12 weeks will be a secondary outcome.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Impact of mental health problems",
-    "description": "The SDQ Impact Supplement measures distress and functional impairment associated with index mental health problems identified on the main SDQ scale. The adolescent-reported SDQ Impact Supplement score will be a secondary outcome, while the corresponding caregiver-reported SDQ Impact Supplement score will be an exploratory outcome.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Internalising symptoms",
-    "description": "Adolescent-reported internalising symptoms will be assessed as a secondary outcome using the combined peer and emotional problem sub-scales of the SDQ. The corresponding caregiver-reported SDQ Internalising score will be an exploratory outcome.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Externalising symptoms",
-    "description": "Adolescent-reported externalising symptoms will be assessed as a secondary outcome using the combined conduct and hyperactivity problem sub-scales of the SDQ. The corresponding caregiver-reported SDQ Externalising score will be an exploratory outcome.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Prosocial behaviour",
-    "description": "Adolescent-reported prosocial behaviour will be assessed as an exploratory outcome using the prosocial sub-scale of the SDQ.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Perceived stress",
-    "description": "The adolescent-reported Perceived Stress Scale-4-item version (PSS-4) will be used as a secondary outcome measure to assess the perception of stress, reflecting the degree to which situations are appraised as stressful during the preceding month (Cohen et al., 1983). This measure was chosen because of its relevance as a presumed mechanism of change within the problem-solving intervention, consistent with stress-coping theory (Lazarus \\& Folkman, 1984). It has been translated into Hindi and used in a number of surveys and as an outcome measure in trials around the world (Lee, 2012).",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Mental wellbeing",
-    "description": "The adolescent-reported Short Warwick-Edinburgh Mental Wellbeing Scale (SWEMWBS) will be used as a secondary measure to assess mental wellbeing (Stewart-Brown et al., 2009), which has been closely linked with social factors such as peer bullying and perception of school connectedness (Patalay \\& Fitzsimons; 2016). It may therefore be especially amenable to problem-solving around common life difficulties encountered by school-going adolescents. The SWEMWBS is widely used internationally (Stewart-Brown, 2013) and a Hindi version is available.",
-    "timeFrame": "12 weeks post-randomization"
-    },
-    {
-    "measure": "Clinical remission",
-    "description": "This secondary outcome will be defined as falling below baseline eligibility cut-offs on both the SDQ Total Difficulties scale and Impact Supplement (i.e. SDQ Total Difficulties score in normal range and Impact score in the normal or borderline range).",
-    "timeFrame": "12 weeks post-randomization"
-    }
-    ]
-    },
-    "eligibilityModule": {
-    "eligibilityCriteria": "Eligibility criteria:\n\nFor adolescent participants:\n\n* Enrolled as a student in Grades 9-12 (corresponding to 13-20 years of age)\n* Experiencing elevated mental health symptoms, based on response in the borderline or abnormal range (scores of 19 or higher for boys and 20 or higher for girls) on the self-reported SDQ Total Difficulties scale\n* Experiencing significant distress and/or functional impairment, based on response in the abnormal range (scores of 2 or higher) on the self-reported SDQ Impact Supplement\n* Experiencing difficulties for \\>1 month, based on response to the self-reported Chronicity item from the SDQ Impact Supplement\n* For adolescents under 18 years of age, able to provide informed assent to participate and supported by parental consent\n* For adolescents over 18 years of age, able to provide informed consent to participate\n\nFor parent participants:\n\n* A primary parental caregiver or guardian for the index adolescent\n* Able to provide informed consent to participate, and if adolescent age 18+ years, parental involvement is supported by the index adolescent\n* Proficient in spoken English or Hindi\n\nExclusion criteria:\n\nFor adolescent participants:\n\n* Requiring urgent medical attention (defined as needing emergency treatment or in-patient admission)\n* Unable to communicate clearly (due to a speech or hearing disability or inability to comprehend one of the program's languages)\n* Already receiving intervention for mental health problems\n* Received PRIDE intervention in past six months during pilot study\n* Not providing assent\n* Adolescent whose parents are not providing consent\n\nFor parent participants:\n\n* Unable to communicate clearly (due to a speech or hearing disability or inability to comprehend one of the program's languages)\n* Intoxicated at the point of consent or assessment",
-    "healthyVolunteers": false,
-    "sex": "ALL",
-    "minimumAge": "13 Years",
-    "maximumAge": "20 Years",
-    "stdAges": [
-    "CHILD",
-    "ADULT"
-    ]
-    },
-    "contactsLocationsModule": {
-    "overallOfficials": [
-    {
-    "name": "Vikram Patel, PhD",
-    "affiliation": "Harvard Medical School (HMS and HSDM)",
-    "role": "PRINCIPAL_INVESTIGATOR"
-    }
-    ],
-    "locations": [
-    {
-    "facility": "Sangath",
-    "city": "New Delhi",
-    "state": "Delhi",
-    "zip": "110016",
-    "country": "India",
-    "geoPoint": {
-    "lat": 28.63576,
-    "lon": 77.22445
-    }
-    }
-    ]
-    },
-    "referencesModule": {
-    "references": [
-    {
-    "pmid": "11102329",
-    "type": "BACKGROUND",
-    "citation": "Goodman R, Ford T, Simmons H, Gatward R, Meltzer H. Using the Strengths and Difficulties Questionnaire (SDQ) to screen for child psychiatric disorders in a community sample. Br J Psychiatry. 2000 Dec;177:534-9. doi: 10.1192/bjp.177.6.534."
-    },
-    {
-    "pmid": "21500888",
-    "type": "BACKGROUND",
-    "citation": "Weisz JR, Chorpita BF, Frye A, Ng MY, Lau N, Bearman SK, Ugueto AM, Langer DA, Hoagwood KE; Research Network on Youth Mental Health. Youth Top Problems: using idiographic, consumer-guided assessment to identify treatment needs and to track change during psychotherapy. J Consult Clin Psychol. 2011 Jun;79(3):369-80. doi: 10.1037/a0023307."
-    },
-    {
-    "pmid": "6668417",
-    "type": "BACKGROUND",
-    "citation": "Cohen S, Kamarck T, Mermelstein R. A global measure of perceived stress. J Health Soc Behav. 1983 Dec;24(4):385-96. No abstract available."
-    },
-    {
-    "pmid": "25031113",
-    "type": "BACKGROUND",
-    "citation": "Lee EH. Review of the psychometric evidence of the perceived stress scale. Asian Nurs Res (Korean Soc Nurs Sci). 2012 Dec;6(4):121-7. doi: 10.1016/j.anr.2012.08.004. Epub 2012 Sep 18."
-    },
-    {
-    "pmid": "19228398",
-    "type": "BACKGROUND",
-    "citation": "Stewart-Brown S, Tennant A, Tennant R, Platt S, Parkinson J, Weich S. Internal construct validity of the Warwick-Edinburgh Mental Well-being Scale (WEMWBS): a Rasch analysis using data from the Scottish Health Education Population Survey. Health Qual Life Outcomes. 2009 Feb 19;7:15. doi: 10.1186/1477-7525-7-15."
-    },
-    {
-    "pmid": "27566118",
-    "type": "BACKGROUND",
-    "citation": "Patalay P, Fitzsimons E. Correlates of Mental Illness and Wellbeing in Children: Are They the Same? Results From the UK Millennium Cohort Study. J Am Acad Child Adolesc Psychiatry. 2016 Sep;55(9):771-83. doi: 10.1016/j.jaac.2016.05.019. Epub 2016 Jun 28."
-    },
-    {
-    "type": "BACKGROUND",
-    "citation": "Lazarus RS, Folkman S. Stress, appraisal, and coping. New York, Springer Pub. Co.; 1984."
-    },
-    {
-    "type": "BACKGROUND",
-    "citation": "Stewart-Brown S. The Warwick-Edinburgh Mental Well-Being Scale (WEMWBS): Performance in Different Cultural and Geographical Groups. In: Keyes CLM, editor. Mental Well-Being: International Contributions to the Study of Positive Mental Health. Dordrecht: Springer Netherlands; 2013. p. 133-50"
-    },
-    {
-    "pmid": "10245370",
-    "type": "BACKGROUND",
-    "citation": "Larsen DL, Attkisson CC, Hargreaves WA, Nguyen TD. Assessment of client/patient satisfaction: development of a general scale. Eval Program Plann. 1979;2(3):197-207. doi: 10.1016/0149-7189(79)90094-6. No abstract available."
-    },
-    {
-    "pmid": "34582460",
-    "type": "DERIVED",
-    "citation": "Malik K, Michelson D, Doyle AM, Weiss HA, Greco G, Sahu R, E J J, Mathur S, Sudhir P, King M, Cuijpers P, Chorpita B, Fairburn CG, Patel V. Effectiveness and costs associated with a lay counselor-delivered, brief problem-solving mental health intervention for adolescents in urban, low-income schools in India: 12-month outcomes of a randomized controlled trial. PLoS Med. 2021 Sep 28;18(9):e1003778. doi: 10.1371/journal.pmed.1003778. eCollection 2021 Sep."
-    },
-    {
-    "pmid": "32585185",
-    "type": "DERIVED",
-    "citation": "Michelson D, Malik K, Parikh R, Weiss HA, Doyle AM, Bhat B, Sahu R, Chilhate B, Mathur S, Krishna M, Sharma R, Sudhir P, King M, Cuijpers P, Chorpita B, Fairburn CG, Patel V. Effectiveness of a brief lay counsellor-delivered, problem-solving intervention for adolescent mental health problems in urban, low-income schools in India: a randomised controlled trial. Lancet Child Adolesc Health. 2020 Aug;4(8):571-582. doi: 10.1016/S2352-4642(20)30173-5. Epub 2020 Jun 23. Erratum In: Lancet Child Adolesc Health. 2020 Jul 23;:"
-    },
-    {
-    "pmid": "31533783",
-    "type": "DERIVED",
-    "citation": "Parikh R, Michelson D, Malik K, Shinde S, Weiss HA, Hoogendoorn A, Ruwaard J, Krishna M, Sharma R, Bhat B, Sahu R, Mathur S, Sudhir P, King M, Cuijpers P, Chorpita BF, Fairburn CG, Patel V. The effectiveness of a low-intensity problem-solving intervention for common adolescent mental health problems in New Delhi, India: protocol for a school-based, individually randomized controlled trial with an embedded stepped-wedge, cluster randomized controlled recruitment trial. Trials. 2019 Sep 18;20(1):568. doi: 10.1186/s13063-019-3573-3."
-    }
-    ]
-    },
-    "ipdSharingStatementModule": {
-    "ipdSharing": "YES",
-    "description": "Anonymised Individual Participant Data along with data dictionaries will be shared with other researchers after 12 months of completion of the trial. Data pertaining to the interventions received and outcomes at primary and secondary end point will be shared upon reasonable requests made to the PI and in accordance with the guidelines of sponsors, collaborators and funder of the study.",
-    "infoTypes": [
-    "STUDY_PROTOCOL",
-    "SAP",
-    "ICF"
-    ],
-    "timeFrame": "12 months after completion of trial.",
-    "accessCriteria": "Access to data will be granted to researchers after review of requests by PI and in accordance with the guidelines of sponsors, collaborators and funder of the study.",
-    "url": "http://datacompass.lshtm.ac.uk/"
-    }
-    },
-    "documentSection": {
-    "largeDocumentModule": {
-    "largeDocs": [
-    {
-    "typeAbbrev": "SAP",
-    "hasProtocol": false,
-    "hasSap": true,
-    "hasIcf": false,
-    "label": "Statistical Analysis Plan",
-    "date": "2019-05-07",
-    "uploadDate": "2019-05-16T06:59",
-    "filename": "SAP_000.pdf",
-    "size": 768149
-    }
-    ]
-    }
-    },
-    "derivedSection": {
-    "miscInfoModule": {
-    "versionHolder": "2023-11-06",
-    "modelPredictions": {
-    "bmiLimits": {
-    "minBmi": 0,
-    "maxBmi": 101
-    }
-    }
-    },
-    "conditionBrowseModule": {
-    "meshes": [
-    {
-    "id": "D000019966",
-    "term": "Substance-Related Disorders"
-    },
-    {
-    "id": "D000010554",
-    "term": "Personality Disorders"
-    }
-    ],
-    "ancestors": [
-    {
-    "id": "D000001523",
-    "term": "Mental Disorders"
-    },
-    {
-    "id": "D000064419",
-    "term": "Chemically-Induced Disorders"
-    }
-    ],
-    "browseLeaves": [
-    {
-    "id": "M6748",
-    "name": "Depression",
-    "relevance": "LOW"
-    },
-    {
-    "id": "M14163",
-    "name": "Psychotic Disorders",
-    "relevance": "LOW"
-    },
-    {
-    "id": "M4505",
-    "name": "Mental Disorders",
-    "relevance": "LOW"
-    },
-    {
-    "id": "M13152",
-    "name": "Personality Disorders",
-    "asFound": "Personality Disorder",
-    "relevance": "HIGH"
-    },
-    {
-    "id": "M6751",
-    "name": "Depressive Disorder",
-    "relevance": "LOW"
-    },
-    {
-    "id": "M21527",
-    "name": "Substance-Related Disorders",
-    "asFound": "Substance Abuse",
-    "relevance": "HIGH"
-    },
-    {
-    "id": "M29992",
-    "name": "Chemically-Induced Disorders",
-    "relevance": "LOW"
-    }
-    ],
-    "browseBranches": [
-    {
-    "abbrev": "BXM",
-    "name": "Behaviors and Mental Disorders"
-    },
-    {
-    "abbrev": "All",
-    "name": "All Conditions"
-    },
-    {
-    "abbrev": "BC25",
-    "name": "Substance Related Disorders"
-    }
-    ]
-    }
-    },
-    "hasResults": false
-    }
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT03630471",
+  "orgStudyIdInfo": {
+  "id": "SANPRIDE_002"
+  },
+  "organization": {
+  "fullName": "Sangath",
+  "class": "OTHER"
+  },
+  "briefTitle": "Effectiveness of a Problem-solving Intervention for Common Adolescent Mental Health Problems in India",
+  "officialTitle": "The Effectiveness of a Low-intensity, Lay Counsellor-delivered, Problem-solving Intervention for Common Mental Health Problems in School-going Adolescents in New Delhi, India: the PRIDE Study Protocol for a Randomized Controlled Trial",
+  "acronym": "PRIDE"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2019-01",
+  "overallStatus": "COMPLETED",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2018-08-20",
+  "type": "ACTUAL"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2019-01-20",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2019-02-28",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2018-08-06",
+  "studyFirstSubmitQcDate": "2018-08-09",
+  "studyFirstPostDateStruct": {
+  "date": "2018-08-14",
+  "type": "ACTUAL"
+  },
+  "lastUpdateSubmitDate": "2019-05-17",
+  "lastUpdatePostDateStruct": {
+  "date": "2019-05-21",
+  "type": "ACTUAL"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "SPONSOR"
+  },
+  "leadSponsor": {
+  "name": "Sangath",
+  "class": "OTHER"
+  },
+  "collaborators": [
+  {
+  "name": "Harvard Medical School (HMS and HSDM)",
+  "class": "OTHER"
+  },
+  {
+  "name": "London School of Hygiene and Tropical Medicine",
+  "class": "OTHER"
+  }
+  ]
+  },
+  "oversightModule": {
+  "oversightHasDmc": true,
+  "isFdaRegulatedDrug": false,
+  "isFdaRegulatedDevice": false
+  },
+  "descriptionModule": {
+  "briefSummary": "We will conduct a two-arm individually randomized controlled trial in six Government-run secondary schools in New Delhi. The targeted sample is 240 adolescents in grades 9-12 with persistent, elevated mental health difficulties and associated impact. Participants will receive either a brief problem-solving intervention delivered by lay counsellors (intervention), or enhanced usual care comprised of problem-solving booklets (control). Self-reported adolescent mental health difficulties and idiographic problems will be assessed at 6 weeks (co-primary outcomes) and again at 12 weeks post-randomization. In addition, adolescent-reported impact of mental health difficulties, perceived stress, mental wellbeing and clinical remission, as well as parent-reported adolescent mental health difficulties and impact scores, will be assessed at 6 and 12 weeks post-randomization. Parallel process evaluation, including estimations of the costs of delivering the interventions, will be conducted.",
+  "detailedDescription": "Background and rationale:\n\nThis study is part of a larger research program called PRIDE (PRemIum for aDolEscents) for which the goals are to:\n\n* develop a trans-diagnostic, stepped-care intervention targeting common mental disorders in school-going adolescents in India; and\n* evaluate its effectiveness in reducing symptom severity and improving recovery rates among adolescent participants\n\nThe components of the stepped-care intervention will be evaluated in separate, linked studies. The main aim of the current trial is to evaluate the effectiveness of a low-intensity problem-solving intervention (the first step of the PRIDE stepped-care intervention) delivered by school counsellors for adolescents with common mental health problems, when compared with enhanced usual care (EUC).\n\nThe primary hypothesis is that the intervention will be superior to the EUC control condition in reducing the severity of self-reported mental health symptoms and prioritized problems at six weeks post-randomization.\n\nStudy design and setting:\n\nThis is a parallel-arm, individually randomized controlled trial with equal allocation of participants between arms. The trial will be conducted in six Government-run secondary schools (Grade 9 to 12; approximately corresponding to 13-20 years of age) from the National Capital Territory of Delhi, India. A process evaluation will be nested in the trial to provide findings that will assist in the interpretation of the trial results and to inform potential implementation of the PRIDE intervention on a wider scale.\n\nEligibility criteria: see 'Eligibility' section.\n\nInterventions: see 'Arms and Interventions' section.\n\nScreening measures: Referred adolescents will be screened for common mental health difficulties, impact and chronicity using the SDQ (Goodman et al., 2000), according to the eligibility criteria set out below.\n\nSociodemographic information: This will be obtained from all enrolled participants through an interviewer-administered questionnaire, with responses entered directly into a tablet computer.\n\nOutcome measures: see 'Outcome Measures' section.\n\nEconomic measures: The costs associated with the introduction of the experimental and control arm interventions will be estimated by adding the personnel costs for counsellors and supervisors, together with fixed costs of training (venue/per diem), furniture and supplies. All costs will be reported in Indian Rupees and then converted to US Dollars at the average daily exchange rate over the preceding 12 months.\n\nProcess measures:\n\nProcess data on enrollment, randomization and assessment procedures will be obtained from researcher-completed record forms. These will be collated to obtain assent/consent rates of adolescents and parents (and reasons for missing assent/consent); randomization rates (and reasons for randomization errors); completion rates of baseline and follow-up outcome assessments (and reasons for non-completion); and time lags between intended and completed assessments (and reasons for deviating from targets). In addition, motivations for help-seeking and expectancies for the school counselling program will be explored at the time of eligibility assessment through a brief qualitative interview with a sub-sample of referred students.\n\nIntervention processes will be assessed using additional data sources. Counsellor-completed session record forms will be used to obtain process data on duration, spacing and frequency of attended sessions (and reasons for non-attendance); and intervention uptake and completion rates (and reasons for pre-intervention and mid-intervention drop-out). Participants' adherence to treatment and potential engagement challenges will be assessed using checklists within the same record forms, indicating whether or not the student completed practice exercises at home, used the POD (Problems-Options-Do it yourself) booklets at home, brought the POD booklets to the session, and demonstrated understanding of POD booklets and session content. Use of POD booklets will be assessed in each arm of the trial at 6- and 12-week follow-up assessments using a brief adolescent-reported measure that asks about estimated frequency of home use and perceived helpfulness of POD booklets in the preceding 6 weeks. Service satisfaction data will also be obtained from participants in each trial arm at 12 weeks using the 8-item Client Satisfaction Questionnaire (CSQ-8) (Larsen et al., 1979). Supplementary questions will elicit open-ended written feedback on the most helpful aspects of the available intervention and suggested modifications.\n\nIntervention fidelity will be assessed using independent ratings of audio-recorded sessions: 10% of all recordings will be selected at random and rated by a psychologist who is not directly involved with supervision of the intervention providers.\n\nSample size:\n\nSample size estimations have been produced for two co-primary outcomes: mental health symptoms (SDQ Total Difficulties score) and idiographic problems (YTP score). A Bonferroni correction has been used to adjust for multiple primary outcomes. Following pilot work that indicated large (uncontrolled) effect sizes, the investigators have conservatively assumed that the intervention will be associated with an effect size of 0.5 (difference in means/SD) on both the primary outcomes with 90% power at 6 weeks post-randomization. The investigators have also assumed a loss to follow up of 15% over 6 weeks, based on pilot work. Based on these assumptions and a 1:1 allocation ratio for individual randomization, a total of 240 participants will be required. This sample size provides 80% power to detect an ES of 0.44.\n\nRecruitment methods and sampling frame:\n\nA combination of whole-school and classroom-based sensitization methods will be used to generate referrals into the trial. This will include posters, teacher briefings and classroom-based information sessions for students. Referrals may be initiated in a number of ways: (1) adolescents can directly approach a researcher following a classroom information session; (2) adolescents can provide their contact details in a 'drop box' placed in the school; or (3) adolescents can request a referral through a teacher (or a teacher may raise the prospect of referral directly with a student before initiating the same). Referred participants will be assessed for eligibility using the SDQ; those meeting eligibility criteria will be invited to participate in the trial. Referred adolescents who do not meet eligibility criteria will receive a handout on self-care strategies.\n\nIn the academic year 2018-19, there are 172 class divisions of grades 9-12 in the six collaborating schools in New Delhi, and approximately 50 students per class. Seventy classes will participate in an embedded recruitment trial (see separate protocol: NCT03633916). The host intervention trial will recruit participants originating from the 70 classes sampled in the embedded recruitment trial, as well as participants drawn from other classes as needed. The precise schedule of recruitment activities in the remaining 102 classes will be calibrated according to referral patterns and caseload capacity for intervention providers in the various schools.\n\nAssent/consent procedures:\n\nReferred adolescents will be invited to meet with a researcher when a 2-stage consent process will be initiated.\n\n1. Assent/consent for using screening data: All referred students who are screened for eligibility will be provided with written information and structured verbal information about the potential use of their screening data for evaluation of help-seeking patterns. Assent, consent will be obtained on signed consent forms.\n2. Assent/consent for trial participation: Eligible students will be provided with additional structured verbal information and a printed participant information sheet about trial participation. Assent will be sought for adolescents who are below 18 years of age, and consent will be sought for adolescents who are 18 years of age or older. For assenting participants aged below 18 years of age, consent from a parent/guardian will be sought by a researcher. This will involve two levels of consent: consent for their child to participate in the trial, and consent for a parent's/guardian's own participation in the study. The informed assent/consent procedure with adolescents will be completed during school hours, while the parent/guardian consent process will be completed at the family's home or another convenient location. Details of assenting/consenting adolescents and consenting parents (and those declining to participate) will be logged on an ongoing basis, along with reasons for non-participation.\n\nData collection procedures (see 'Outcome Measures' for detailed descriptions of measures referenced below):\n\nField researchers will administer outcome measures in schools, at home or other convenient locations. The adolescent-reported SDQ will be collected by a field researcher on a digital tablet device, and will also serve as the basis for eligibility screening. Other baseline assessments will be completed as soon as possible after assent/consent procedures are completed (and ideally on the same day). The YTP will be administered on paper while the remaining scales will be administered on a digital tablet device. The YTP will be administered on paper as it asks the participants to describe, prioritize and score their three main problems; the same list of problems will be rated again during follow-up assessments (see below). Adolescents will also be assessed on the PSS-4 and SWEMWBS. Index parents will be invited to complete the SDQ only. Sociodemographic data from the adolescent and parent/guardian will also be collected on digital tablets.\n\nFollow-up assessments will be completed at 6 and 12 weeks post-randomization. The 6-week outcome is the primary end-point, as the optimal effect of the intervention is expected to occur immediately after the intervention has been completed. The 12-week end-point is included to evaluate the durability of intervention effects. The CSQ-8 (a process measure of service satisfaction) will be collected at 12 weeks post-randomization only. Additionally, all adolescents will complete a self-report measure on the use of the intervention materials (problem-solving booklets) provided in the intervention and control arms.\n\nData analysis plan:\n\nDescriptive analyses: Initial analyses will compare baseline characteristics of referred adolescents who did and did were not enrolled into the trial for various reasons. Baseline characteristics of enrolled participants will be compared between trial arms. Findings will be reported as per the CONSORT guidelines, using intention-to-treat analysis, including a trial flow chart.\n\nOutcome measures will be summarized at recruitment, at 6- and 12-week follow up by trial arm, and overall. These will be summarized by means (standard deviation), medians (interquartile range), or numbers and proportions as appropriate. For continuous outcomes, histograms will also be plotted within each arm to assess how closely the scales follow a normal distribution. This will determine how the outcomes are described as well as the choice of inferential analysis method.\n\nOutcome analyses: The primary analyses will be on an intention-to-treat basis at the 6-week end-point, adjusted for baseline values of the outcome measure; school (as a fixed effect in the analysis) to allow for within-school clustering, counsellor variation (as a random effect); and variables for which randomization did not achieve reasonable balance between the arms at baseline, or those associated with missing outcome data. Intervention effects will be presented as adjusted mean differences and effect sizes (ES), defined as standardized mean differences.\n\nFor continuous variables, the analysis of secondary and exploratory outcomes will use similar methods to the primary outcome analysis for continuous variables. For the binary outcome (remission), the intervention effect will be reported as the adjusted odds ratio with 95% CIs. Generalized (linear or logistic) random-effects regression models will be used, adjusting for baseline outcome score and clustering, and other baseline variables as above. For outcomes to be examined over the 12-week follow-up period (other than remission), regression models will include a variable to represent 'time' in order to indicate whether the data were collected at the 6- or 12-week end-point. To assess whether the intervention effect varies over time, an intervention x time interaction term will be fitted to allow for a different intervention effect at 6 vs 12 months, although this will not be highly powered.\n\nWe will explore potential moderators of intervention effects, with respect to a priori defined modifiers (i.e. chronicity of mental health difficulties, severity of mental health difficulties, YTP type, SDQ caseness profile). We will fit relevant interaction terms and test for heterogeneity of intervention effects in regression models. A mediation analysis will be conducted to examine whether the theoretically-driven a priori factor (perceived stress at 6 weeks) mediates the effects of the intervention on primary outcomes (i.e. mental health symptoms and idiographic problems) at 12 weeks. Additionally, intervention effects for students who receive fewer sessions than prescribed will be estimated using the Complier Average Causal Effect structural equation model.\n\nProcess evaluation: We will undertake descriptive statistical analysis of quantitative process data in order to explore the implementation of intervention procedures. In addition, thematic analysis will be used to code and organise qualitative interview data on intervention expectancies (assessed prior to enrolment) and qualitative written feedback on service satisfaction (assessed at 12-week follow-up). Findings from the various data sources will be triangulated and used to develop explanatory hypotheses about potential differences in intervention delivery and engagement across schools, subgroups of participants and providers. Process evaluation findings will be used to facilitate interpretation of the main trial results. The trial statisticians may conduct further analyses to test hypotheses generated from integration of the process evaluation and trial outcome data.\n\nCost-effectiveness analysis: The costs associated with the introduction of the PRIDE and control arm interventions will be estimated by adding the fixed costs of materials and personnel costs."
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Mental Health Issue (E.G., Depression, Psychosis, Personality Disorder, Substance Abuse)"
+  ],
+  "keywords": [
+  "Adolescents"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "NA"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "interventionModelDescription": "A two-arm, individually randomized controlled trial with equal allocation of participants between arms.",
+  "primaryPurpose": "TREATMENT",
+  "maskingInfo": {
+  "masking": "DOUBLE",
+  "maskingDescription": "The randomization list will be generated by an independent statistician. The randomization code will be concealed using sequentially numbered opaque sealed envelopes to maximize allocation concealment.\n\nBaseline assessments will be carried out by field researchers prior to randomization. The six- and 12-week outcome assessments will be carried out by a team of field researchers who will be blind to allocation status.",
+  "whoMasked": [
+  "INVESTIGATOR",
+  "OUTCOMES_ASSESSOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 250,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "Control",
+  "type": "ACTIVE_COMPARATOR",
+  "description": "Enhanced usual care (problem-solving booklets only).",
+  "interventionNames": [
+  "Behavioral: Enhanced usual care"
+  ]
+  },
+  {
+  "label": "Intervention",
+  "type": "EXPERIMENTAL",
+  "description": "PRIDE 'Step 1' problem-solving intervention.",
+  "interventionNames": [
+  "Behavioral: PRIDE 'Step 1' problem-solving intervention"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "BEHAVIORAL",
+  "name": "PRIDE 'Step 1' problem-solving intervention",
+  "description": "The PRIDE problem-solving intervention is one component of the PRIDE stepped care treatment architecture which comprises two sequential treatments of incremental intensity. 'Step 1' is a brief, first-line treatment. It is grounded in stress-coping theory, with a technical focus on practical problem-solving to modify developmentally salient stressors.\n\nStep 1 has been designed as a 'low-intensity' intervention requiring fewer resources than conventional psychological treatments. This is achieved through a relatively brief delivery schedule (up to 5 x 20-30-minute sessions spread over approximately 3 weeks) and limited requirement for specialists. The delivery agents are lay counsellors receiving a combination of specialist and peer supervision. The counsellors offer guidance sessions to support the learning and implementation of problem-solving and complementary coping skills. Illustrated booklets are used to support learning of problem-solving concepts and skills practice at home.",
+  "armGroupLabels": [
+  "Intervention"
+  ]
+  },
+  {
+  "type": "BEHAVIORAL",
+  "name": "Enhanced usual care",
+  "description": "There is no established mental health service provision in the collaborating schools. The control arm participants will receive an enhancement of this 'usual care' (essentially, no care) by having access to the same illustrated booklets used in the Intervention arm, albeit without any counsellor contact.",
+  "armGroupLabels": [
+  "Control"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  "primaryOutcomes": [
+  {
+  "measure": "Mental health symptoms",
+  "description": "The Strengths and Difficulties Questionnaire (SDQ) is a 25-item self-report measure of youth mental health symptoms (Goodman et al., 2000). A Total Difficulties score is derived by summing items from four problem subscales (Emotional, Conduct, Hyperactivity/inattention and Peer problems). The measure is the most widely used clinical and research instrument in the field of child and adolescent mental health globally. The Hindi version will be used in complementary forms for self-report by adolescents and parents. The adolescent-reported SDQ Total Difficulties score (at 6-week end-point) will be a co-primary outcome, while the corresponding caregiver-reported SDQ Total Difficulties score will be an exploratory outcome.",
+  "timeFrame": "6 weeks"
+  },
+  {
+  "measure": "Idiographic problems",
+  "description": "The Youth Top Problems (YTP) is a brief, idiographic measure which identifies, prioritizes and scores respondents' three main problems (Weisz et al., 2011). Each nominated problem is scored from 0 ('not a problem') to 10 ('huge problem'). A mean severity score is calculated by summing individual problem scores and then dividing by the number of nominated problems. The YTP will be used to assess problems that other scales might address generally or otherwise miss; while providing a sensitive measure of specific priorities of the participant within a larger array of problems.",
+  "timeFrame": "6 weeks"
+  }
+  ],
+  "secondaryOutcomes": [
+  {
+  "measure": "Mental health symptoms",
+  "description": "The adolescent-reported SDQ Total Difficulties score at 12 weeks will be a secondary outcome, while the corresponding caregiver-reported SDQ Total Difficulties score will be an exploratory outcome.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Idiographic problems",
+  "description": "The adolescent-reported YTP severity score at 12 weeks will be a secondary outcome.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Impact of mental health problems",
+  "description": "The SDQ Impact Supplement measures distress and functional impairment associated with index mental health problems identified on the main SDQ scale. The adolescent-reported SDQ Impact Supplement score will be a secondary outcome, while the corresponding caregiver-reported SDQ Impact Supplement score will be an exploratory outcome.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Internalising symptoms",
+  "description": "Adolescent-reported internalising symptoms will be assessed as a secondary outcome using the combined peer and emotional problem sub-scales of the SDQ. The corresponding caregiver-reported SDQ Internalising score will be an exploratory outcome.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Externalising symptoms",
+  "description": "Adolescent-reported externalising symptoms will be assessed as a secondary outcome using the combined conduct and hyperactivity problem sub-scales of the SDQ. The corresponding caregiver-reported SDQ Externalising score will be an exploratory outcome.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Prosocial behaviour",
+  "description": "Adolescent-reported prosocial behaviour will be assessed as an exploratory outcome using the prosocial sub-scale of the SDQ.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Perceived stress",
+  "description": "The adolescent-reported Perceived Stress Scale-4-item version (PSS-4) will be used as a secondary outcome measure to assess the perception of stress, reflecting the degree to which situations are appraised as stressful during the preceding month (Cohen et al., 1983). This measure was chosen because of its relevance as a presumed mechanism of change within the problem-solving intervention, consistent with stress-coping theory (Lazarus \\& Folkman, 1984). It has been translated into Hindi and used in a number of surveys and as an outcome measure in trials around the world (Lee, 2012).",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Mental wellbeing",
+  "description": "The adolescent-reported Short Warwick-Edinburgh Mental Wellbeing Scale (SWEMWBS) will be used as a secondary measure to assess mental wellbeing (Stewart-Brown et al., 2009), which has been closely linked with social factors such as peer bullying and perception of school connectedness (Patalay \\& Fitzsimons; 2016). It may therefore be especially amenable to problem-solving around common life difficulties encountered by school-going adolescents. The SWEMWBS is widely used internationally (Stewart-Brown, 2013) and a Hindi version is available.",
+  "timeFrame": "12 weeks post-randomization"
+  },
+  {
+  "measure": "Clinical remission",
+  "description": "This secondary outcome will be defined as falling below baseline eligibility cut-offs on both the SDQ Total Difficulties scale and Impact Supplement (i.e. SDQ Total Difficulties score in normal range and Impact score in the normal or borderline range).",
+  "timeFrame": "12 weeks post-randomization"
+  }
+  ]
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Eligibility criteria:\n\nFor adolescent participants:\n\n* Enrolled as a student in Grades 9-12 (corresponding to 13-20 years of age)\n* Experiencing elevated mental health symptoms, based on response in the borderline or abnormal range (scores of 19 or higher for boys and 20 or higher for girls) on the self-reported SDQ Total Difficulties scale\n* Experiencing significant distress and/or functional impairment, based on response in the abnormal range (scores of 2 or higher) on the self-reported SDQ Impact Supplement\n* Experiencing difficulties for \\>1 month, based on response to the self-reported Chronicity item from the SDQ Impact Supplement\n* For adolescents under 18 years of age, able to provide informed assent to participate and supported by parental consent\n* For adolescents over 18 years of age, able to provide informed consent to participate\n\nFor parent participants:\n\n* A primary parental caregiver or guardian for the index adolescent\n* Able to provide informed consent to participate, and if adolescent age 18+ years, parental involvement is supported by the index adolescent\n* Proficient in spoken English or Hindi\n\nExclusion criteria:\n\nFor adolescent participants:\n\n* Requiring urgent medical attention (defined as needing emergency treatment or in-patient admission)\n* Unable to communicate clearly (due to a speech or hearing disability or inability to comprehend one of the program's languages)\n* Already receiving intervention for mental health problems\n* Received PRIDE intervention in past six months during pilot study\n* Not providing assent\n* Adolescent whose parents are not providing consent\n\nFor parent participants:\n\n* Unable to communicate clearly (due to a speech or hearing disability or inability to comprehend one of the program's languages)\n* Intoxicated at the point of consent or assessment",
+  "healthyVolunteers": false,
+  "sex": "ALL",
+  "minimumAge": "13 Years",
+  "maximumAge": "20 Years",
+  "stdAges": [
+  "CHILD",
+  "ADULT"
+  ]
+  },
+  "contactsLocationsModule": {
+  "overallOfficials": [
+  {
+  "name": "Vikram Patel, PhD",
+  "affiliation": "Harvard Medical School (HMS and HSDM)",
+  "role": "PRINCIPAL_INVESTIGATOR"
+  }
+  ],
+  "locations": [
+  {
+  "facility": "Sangath",
+  "city": "New Delhi",
+  "state": "Delhi",
+  "zip": "110016",
+  "country": "India",
+  "geoPoint": {
+  "lat": 28.63576,
+  "lon": 77.22445
+  }
+  }
+  ]
+  },
+  "referencesModule": {
+  "references": [
+  {
+  "pmid": "11102329",
+  "type": "BACKGROUND",
+  "citation": "Goodman R, Ford T, Simmons H, Gatward R, Meltzer H. Using the Strengths and Difficulties Questionnaire (SDQ) to screen for child psychiatric disorders in a community sample. Br J Psychiatry. 2000 Dec;177:534-9. doi: 10.1192/bjp.177.6.534."
+  },
+  {
+  "pmid": "21500888",
+  "type": "BACKGROUND",
+  "citation": "Weisz JR, Chorpita BF, Frye A, Ng MY, Lau N, Bearman SK, Ugueto AM, Langer DA, Hoagwood KE; Research Network on Youth Mental Health. Youth Top Problems: using idiographic, consumer-guided assessment to identify treatment needs and to track change during psychotherapy. J Consult Clin Psychol. 2011 Jun;79(3):369-80. doi: 10.1037/a0023307."
+  },
+  {
+  "pmid": "6668417",
+  "type": "BACKGROUND",
+  "citation": "Cohen S, Kamarck T, Mermelstein R. A global measure of perceived stress. J Health Soc Behav. 1983 Dec;24(4):385-96. No abstract available."
+  },
+  {
+  "pmid": "25031113",
+  "type": "BACKGROUND",
+  "citation": "Lee EH. Review of the psychometric evidence of the perceived stress scale. Asian Nurs Res (Korean Soc Nurs Sci). 2012 Dec;6(4):121-7. doi: 10.1016/j.anr.2012.08.004. Epub 2012 Sep 18."
+  },
+  {
+  "pmid": "19228398",
+  "type": "BACKGROUND",
+  "citation": "Stewart-Brown S, Tennant A, Tennant R, Platt S, Parkinson J, Weich S. Internal construct validity of the Warwick-Edinburgh Mental Well-being Scale (WEMWBS): a Rasch analysis using data from the Scottish Health Education Population Survey. Health Qual Life Outcomes. 2009 Feb 19;7:15. doi: 10.1186/1477-7525-7-15."
+  },
+  {
+  "pmid": "27566118",
+  "type": "BACKGROUND",
+  "citation": "Patalay P, Fitzsimons E. Correlates of Mental Illness and Wellbeing in Children: Are They the Same? Results From the UK Millennium Cohort Study. J Am Acad Child Adolesc Psychiatry. 2016 Sep;55(9):771-83. doi: 10.1016/j.jaac.2016.05.019. Epub 2016 Jun 28."
+  },
+  {
+  "type": "BACKGROUND",
+  "citation": "Lazarus RS, Folkman S. Stress, appraisal, and coping. New York, Springer Pub. Co.; 1984."
+  },
+  {
+  "type": "BACKGROUND",
+  "citation": "Stewart-Brown S. The Warwick-Edinburgh Mental Well-Being Scale (WEMWBS): Performance in Different Cultural and Geographical Groups. In: Keyes CLM, editor. Mental Well-Being: International Contributions to the Study of Positive Mental Health. Dordrecht: Springer Netherlands; 2013. p. 133-50"
+  },
+  {
+  "pmid": "10245370",
+  "type": "BACKGROUND",
+  "citation": "Larsen DL, Attkisson CC, Hargreaves WA, Nguyen TD. Assessment of client/patient satisfaction: development of a general scale. Eval Program Plann. 1979;2(3):197-207. doi: 10.1016/0149-7189(79)90094-6. No abstract available."
+  },
+  {
+  "pmid": "34582460",
+  "type": "DERIVED",
+  "citation": "Malik K, Michelson D, Doyle AM, Weiss HA, Greco G, Sahu R, E J J, Mathur S, Sudhir P, King M, Cuijpers P, Chorpita B, Fairburn CG, Patel V. Effectiveness and costs associated with a lay counselor-delivered, brief problem-solving mental health intervention for adolescents in urban, low-income schools in India: 12-month outcomes of a randomized controlled trial. PLoS Med. 2021 Sep 28;18(9):e1003778. doi: 10.1371/journal.pmed.1003778. eCollection 2021 Sep."
+  },
+  {
+  "pmid": "32585185",
+  "type": "DERIVED",
+  "citation": "Michelson D, Malik K, Parikh R, Weiss HA, Doyle AM, Bhat B, Sahu R, Chilhate B, Mathur S, Krishna M, Sharma R, Sudhir P, King M, Cuijpers P, Chorpita B, Fairburn CG, Patel V. Effectiveness of a brief lay counsellor-delivered, problem-solving intervention for adolescent mental health problems in urban, low-income schools in India: a randomised controlled trial. Lancet Child Adolesc Health. 2020 Aug;4(8):571-582. doi: 10.1016/S2352-4642(20)30173-5. Epub 2020 Jun 23. Erratum In: Lancet Child Adolesc Health. 2020 Jul 23;:"
+  },
+  {
+  "pmid": "31533783",
+  "type": "DERIVED",
+  "citation": "Parikh R, Michelson D, Malik K, Shinde S, Weiss HA, Hoogendoorn A, Ruwaard J, Krishna M, Sharma R, Bhat B, Sahu R, Mathur S, Sudhir P, King M, Cuijpers P, Chorpita BF, Fairburn CG, Patel V. The effectiveness of a low-intensity problem-solving intervention for common adolescent mental health problems in New Delhi, India: protocol for a school-based, individually randomized controlled trial with an embedded stepped-wedge, cluster randomized controlled recruitment trial. Trials. 2019 Sep 18;20(1):568. doi: 10.1186/s13063-019-3573-3."
+  }
+  ]
+  },
+  "ipdSharingStatementModule": {
+  "ipdSharing": "YES",
+  "description": "Anonymised Individual Participant Data along with data dictionaries will be shared with other researchers after 12 months of completion of the trial. Data pertaining to the interventions received and outcomes at primary and secondary end point will be shared upon reasonable requests made to the PI and in accordance with the guidelines of sponsors, collaborators and funder of the study.",
+  "infoTypes": [
+  "STUDY_PROTOCOL",
+  "SAP",
+  "ICF"
+  ],
+  "timeFrame": "12 months after completion of trial.",
+  "accessCriteria": "Access to data will be granted to researchers after review of requests by PI and in accordance with the guidelines of sponsors, collaborators and funder of the study.",
+  "url": "http://datacompass.lshtm.ac.uk/"
+  }
+  },
+  "documentSection": {
+  "largeDocumentModule": {
+  "largeDocs": [
+  {
+  "typeAbbrev": "SAP",
+  "hasProtocol": false,
+  "hasSap": true,
+  "hasIcf": false,
+  "label": "Statistical Analysis Plan",
+  "date": "2019-05-07",
+  "uploadDate": "2019-05-16T06:59",
+  "filename": "SAP_000.pdf",
+  "size": 768149
+  }
+  ]
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2023-11-06",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000019966",
+  "term": "Substance-Related Disorders"
+  },
+  {
+  "id": "D000010554",
+  "term": "Personality Disorders"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000001523",
+  "term": "Mental Disorders"
+  },
+  {
+  "id": "D000064419",
+  "term": "Chemically-Induced Disorders"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M6748",
+  "name": "Depression",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M14163",
+  "name": "Psychotic Disorders",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M4505",
+  "name": "Mental Disorders",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M13152",
+  "name": "Personality Disorders",
+  "asFound": "Personality Disorder",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M6751",
+  "name": "Depressive Disorder",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M21527",
+  "name": "Substance-Related Disorders",
+  "asFound": "Substance Abuse",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M29992",
+  "name": "Chemically-Induced Disorders",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BXM",
+  "name": "Behaviors and Mental Disorders"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  },
+  {
+  "abbrev": "BC25",
+  "name": "Substance Related Disorders"
+  }
+  ]
+  }
+  },
+  "hasResults": false
+  }


### PR DESCRIPTION
Go to rails console:
run comands in order:

`hash = JSON.parse(File.read('spec/support/json_data/NCT02210780.json'))`
`processor = StudyJsonRecord::ProcessorV2.new(hash)`
`processor.result_agreement_data`
