### PR TITLE
AACT-622: Create ipd_information_types_data mapper method in the v2 processor

### DIFF
--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -233,7 +233,12 @@ class StudyJsonRecord::ProcessorV2
     ipd_sharing_info_types = protocol_section.dig('ipdSharingStatementModule', 'infoTypes')
     return unless ipd_sharing_info_types
 
-    { nct_id: nct_id, name: ipd_sharing_info_types }
+    collection = []
+    ipd_sharing_info_types.each do |info|
+      collection << { nct_id: nct_id, name: info }
+    end
+
+    collection
   end
 
   def keywords_data

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -227,6 +227,13 @@ class StudyJsonRecord::ProcessorV2
   end
 
   def ipd_information_types_data
+    return unless protocol_section
+
+    nct_id = protocol_section.dig('identificationModule', 'nctId')
+    ipd_sharing_info_types = protocol_section.dig('ipdSharingStatementModule', 'infoTypes')
+    return unless ipd_sharing_info_types
+
+    { nct_id: nct_id, name: ipd_sharing_info_types }
   end
 
   def keywords_data

--- a/spec/models/study_json_record/processor_v2_spec.rb
+++ b/spec/models/study_json_record/processor_v2_spec.rb
@@ -329,4 +329,20 @@ RSpec.describe StudyJsonRecord::ProcessorV2, type: :model do
     end
   end
 
+  describe '#ipd_information_types_data' do
+    it 'should use JSON API to generate data that will be inserted into the ipd information types table' do
+      expected_data = {
+        nct_id: "NCT03630471",
+        name: [
+          "STUDY_PROTOCOL",
+          "SAP",
+          "ICF"
+        ]
+      }
+      hash = JSON.parse(File.read('spec/support/json_data/NCT03630471.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(processor.ipd_information_types_data).to eq(expected_data)
+    end
+  end
+
 end

--- a/spec/models/study_json_record/processor_v2_spec.rb
+++ b/spec/models/study_json_record/processor_v2_spec.rb
@@ -331,14 +331,11 @@ RSpec.describe StudyJsonRecord::ProcessorV2, type: :model do
 
   describe '#ipd_information_types_data' do
     it 'should use JSON API to generate data that will be inserted into the ipd information types table' do
-      expected_data = {
-        nct_id: "NCT03630471",
-        name: [
-          "STUDY_PROTOCOL",
-          "SAP",
-          "ICF"
-        ]
-      }
+      expected_data = [
+        { nct_id: "NCT03630471", name: "STUDY_PROTOCOL" },
+        { nct_id: "NCT03630471", name: "SAP" },
+        { nct_id: "NCT03630471", name: "ICF" }
+      ]
       hash = JSON.parse(File.read('spec/support/json_data/NCT03630471.json'))
       processor = StudyJsonRecord::ProcessorV2.new(hash)
       expect(processor.ipd_information_types_data).to eq(expected_data)


### PR DESCRIPTION
- Created ipd_information_types_data mapper method in the v2 processor
- Added RSpec test case for the ipd_information_types_data method
- Test Case PASS in processor_v2_spec.rb:

<img width="1239" alt="Screen Shot 2023-12-13 at 10 21 30 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/2e3298d1-2d96-4435-8880-200ec706e2cf">
