### PR TITLE
AACT-628: Create design_outcomes_data mapper method for the v2 API

### DIFF
--- a/app/models/design_outcome.rb
+++ b/app/models/design_outcome.rb
@@ -1,27 +1,62 @@
-class DesignOutcome < StudyRelationship
-  attr_accessor :type
+class DesignOutcome < ApplicationRecord
+  # attr_accessor :type
 
-  def self.create_all_from(options={})
-    nct_id=options[:nct_id]
-    primary=options[:xml].xpath("//primary_outcome").collect{|xml|
-      create_from({:xml=>xml,:type=>'primary',:nct_id=>nct_id})}
+  # def self.create_all_from(options={})
+  #   nct_id=options[:nct_id]
+  #   primary=options[:xml].xpath("//primary_outcome").collect{|xml|
+  #     create_from({:xml=>xml,:type=>'primary',:nct_id=>nct_id})}
 
-    secondary=options[:xml].xpath("//secondary_outcome").collect{|xml|
-      create_from({:xml=>xml,:type=>'secondary',:nct_id=>nct_id})}
+  #   secondary=options[:xml].xpath("//secondary_outcome").collect{|xml|
+  #     create_from({:xml=>xml,:type=>'secondary',:nct_id=>nct_id})}
 
-    other=options[:xml].xpath("//other_outcome").collect{|xml|
-      create_from({:xml=>xml,:type=>'other',:nct_id=>nct_id})}
-    import(primary + secondary + other)
+  #   other=options[:xml].xpath("//other_outcome").collect{|xml|
+  #     create_from({:xml=>xml,:type=>'other',:nct_id=>nct_id})}
+  #   import(primary + secondary + other)
+  # end
+
+  # def attribs
+  #   {
+  #     :measure => get('measure'),
+  #     :time_frame => get('time_frame'),
+  #     :description => get('description'),
+  #     :population => get('population'),
+  #     :outcome_type => get_opt(:type)
+  #   }
+  # end
+
+  def self.mapper(json)
+    return unless json.protocol_section
+
+    primary_outcomes = outcome_list('primaryOutcomes')
+    secondary_outcomes = outcome_list('secondaryOutcomes')
+    other_outcomes = outcome_list('otherOutcomes')
+    primary_outcomes ||= []
+    secondary_outcomes ||= []
+    other_outcomes ||= []
+    total = primary_outcomes + secondary_outcomes + other_outcomes
+    return nil if total.empty?
+
+    total
   end
 
-  def attribs
-    {
-      :measure => get('measure'),
-      :time_frame => get('time_frame'),
-      :description => get('description'),
-      :population => get('population'),
-      :outcome_type => get_opt(:type)
-    }
+  def outcome_list(outcome_type='primaryOutcomes')
+    outcomes = json.protocol_section['outcomesModule']
+    return unless outcomes
+
+    nct_id = json.protocol_section.dig('identificationModule', 'nctId')
+
+    collection = []
+    outcomes.each do |outcome|
+      collection << {
+                      nct_id: nct_id,
+                      outcome_type: outcome_type.downcase,
+                      measure: outcome["#{outcome_type}measure"],
+                      time_frame: outcome["#{outcome_type}timeFrame"],
+                      population: nil,
+                      description: outcome["#{outcome_type}description"]
+                    }
+    end
+    collection
   end
 
 end

--- a/app/models/design_outcome.rb
+++ b/app/models/design_outcome.rb
@@ -1,46 +1,22 @@
 class DesignOutcome < ApplicationRecord
-  # attr_accessor :type
-
-  # def self.create_all_from(options={})
-  #   nct_id=options[:nct_id]
-  #   primary=options[:xml].xpath("//primary_outcome").collect{|xml|
-  #     create_from({:xml=>xml,:type=>'primary',:nct_id=>nct_id})}
-
-  #   secondary=options[:xml].xpath("//secondary_outcome").collect{|xml|
-  #     create_from({:xml=>xml,:type=>'secondary',:nct_id=>nct_id})}
-
-  #   other=options[:xml].xpath("//other_outcome").collect{|xml|
-  #     create_from({:xml=>xml,:type=>'other',:nct_id=>nct_id})}
-  #   import(primary + secondary + other)
-  # end
-
-  # def attribs
-  #   {
-  #     :measure => get('measure'),
-  #     :time_frame => get('time_frame'),
-  #     :description => get('description'),
-  #     :population => get('population'),
-  #     :outcome_type => get_opt(:type)
-  #   }
-  # end
-
+ 
   def self.mapper(json)
     return unless json.protocol_section
 
-    primary_outcomes = outcome_list('primaryOutcomes')
-    secondary_outcomes = outcome_list('secondaryOutcomes')
-    other_outcomes = outcome_list('otherOutcomes')
+    primary_outcomes = outcome_list(json, 'primaryOutcomes')
+    secondary_outcomes = outcome_list(json, 'secondaryOutcomes')
+    other_outcomes = outcome_list(json, 'otherOutcomes')
     primary_outcomes ||= []
     secondary_outcomes ||= []
     other_outcomes ||= []
     total = primary_outcomes + secondary_outcomes + other_outcomes
     return nil if total.empty?
-
+    byebug
     total
   end
 
-  def outcome_list(outcome_type='primaryOutcomes')
-    outcomes = json.protocol_section['outcomesModule']
+  def self.outcome_list(json, outcome_type='primaryOutcomes')
+    outcomes = json.protocol_section.dig('outcomesModule', outcome_type)
     return unless outcomes
 
     nct_id = json.protocol_section.dig('identificationModule', 'nctId')
@@ -50,12 +26,13 @@ class DesignOutcome < ApplicationRecord
       collection << {
                       nct_id: nct_id,
                       outcome_type: outcome_type.downcase,
-                      measure: outcome["#{outcome_type}measure"],
-                      time_frame: outcome["#{outcome_type}timeFrame"],
+                      measure: outcome['measure'],
+                      time_frame: outcome['timeFrame'],
                       population: nil,
-                      description: outcome["#{outcome_type}description"]
+                      description: outcome['description']
                     }
     end
+
     collection
   end
 

--- a/app/models/design_outcome.rb
+++ b/app/models/design_outcome.rb
@@ -11,7 +11,7 @@ class DesignOutcome < ApplicationRecord
     other_outcomes ||= []
     total = primary_outcomes + secondary_outcomes + other_outcomes
     return nil if total.empty?
-    byebug
+    
     total
   end
 

--- a/app/models/study_json_record/processor_v2.rb
+++ b/app/models/study_json_record/processor_v2.rb
@@ -345,9 +345,6 @@ class StudyJsonRecord::ProcessorV2
   def overall_officials_data
   end
 
-  def design_outcomes_data
-  end
-
   def pending_results_data
   end
 

--- a/spec/models/design_outcome_spec.rb
+++ b/spec/models/design_outcome_spec.rb
@@ -1,29 +1,116 @@
 require 'rails_helper'
 
 RSpec.describe DesignOutcome do
+
   describe 'DesignOutcome#mapper' do
-    it 'study should have expected design_outcomes_data info' do
+    it 'should have expected primary, secondary, and other design outcomes data' do
       expected_data = [
         { 
-          nct_id: 'NCT03064438', 
-          outcome_type: 'primaryOutcomes', 
-          measure: 'Change From Baseline in Total Lesion Count at Week 12',
-          time_frame: 'Baseline, Week 12', 
-          population: false, 
-          description: 'Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter.'
+          nct_id: "NCT03064438", 
+          outcome_type: "primaryoutcomes", 
+          measure: "Change From Baseline in Total Lesion Count at Week 12",
+          time_frame: "Baseline, Week 12", 
+          population: nil, 
+          description: "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter."
         },
         { 
-          nct_id: 'NCT03064438', 
-          outcome_type: 'secondaryOutcomes', 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
           measure: "Percent Change From Baseline in Investigator's Global Assessment (IGA) Score at Weeks 2, 4, 8, and 12",
-          time_frame: 'Baseline; Weeks 2, 4, 8, and 12', 
-          population: false, 
-          description: 'The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema'
+          time_frame: "Baseline; Weeks 2, 4, 8, and 12", 
+          population: nil, 
+          description: "The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Percentage of Participants Who Were Treatment Responders at Week 12",
+          time_frame: "Baseline, Week 12", 
+          population: nil, 
+          description: "Treatment responders were defined as participants who have either (1) 2 ordinal or more reductions in the IGA score from baseline or (2) an IGA score of 0 or 1.\n\nThe IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Change From Baseline in Papule Lesions at Weeks 2, 4, 8, and 12",
+          time_frame: "Baseline; Weeks 2, 4, 8, and 12", 
+          population: nil, 
+          description: "Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Change From Baseline in Pustule Lesions at Weeks 2, 4, 8, and 12",
+          time_frame: "Baseline; Weeks 2, 4, 8, and 12", 
+          population: nil, 
+          description: "Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Change From Baseline in Nodule Lesions at Weeks 2, 4, 8, and 12",
+          time_frame: "Baseline; Weeks 2, 4, 8, and 12", 
+          population: nil, 
+          description: "Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Change From Baseline in Papules + Pustules Lesions at Weeks 2, 4, 8, and 12",
+          time_frame: "Baseline; Weeks 2, 4, 8, and 12", 
+          population: nil, 
+          description: "Papules + pustules lesions were the sum of counts of papule (raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material) and pustule (raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material) lesions."
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Number of Participants With Adverse Events",
+          time_frame: "Baseline to Week 14", 
+          population: nil, 
+          description: "Number of participants reporting any adverse event including local tolerability of signs and symptoms of irritation, clinical laboratory safety tests, and vital signs."
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "otheroutcomes", 
+          measure: "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Week 12",
+          time_frame: "Week 12", 
+          population: nil, 
+          description: "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema"
+        },
+        { 
+          nct_id: "NCT03064438", 
+          outcome_type: "otheroutcomes", 
+          measure: "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+          time_frame: "Day 1 (Post-application) and Weeks 2, 4, 8, and 14", 
+          population: nil, 
+          description: "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema"
         }
       ]
       hash = JSON.parse(File.read('spec/support/json_data/NCT03064438.json'))
       processor = StudyJsonRecord::ProcessorV2.new(hash)
       expect(DesignOutcome.mapper(processor)).to eq(expected_data)
+    end
+
+    it 'should return nil when design outcomes data is empty' do
+      hash = JSON.parse(File.read('spec/support/json_data/design_outcome_empty.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(DesignOutcome.mapper(processor)).to eq(nil)  
+    end
+    
+    it 'should have expected primary design outcomes data' do
+      expected_data = [
+        { 
+          nct_id: "NCT", 
+          outcome_type: "primaryoutcomes", 
+          measure: "",
+          time_frame: "", 
+          population: nil, 
+          description: ""
+        }
+      ]
+      hash = JSON.parse(File.read('spec/support/json_data/design_outcome_empty.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(DesignOutcome.mapper(processor)).to eq(expected_data)  
     end
   end  
 end

--- a/spec/models/design_outcome_spec.rb
+++ b/spec/models/design_outcome_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DesignOutcome do
+  describe 'DesignOutcome#mapper' do
+    it 'study should have expected design_outcomes_data info' do
+      expected_data = [
+        { 
+          nct_id: 'NCT03064438', 
+          outcome_type: 'primaryOutcomes', 
+          measure: 'Change From Baseline in Total Lesion Count at Week 12',
+          time_frame: 'Baseline, Week 12', 
+          population: false, 
+          description: 'Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter.'
+        },
+        { 
+          nct_id: 'NCT03064438', 
+          outcome_type: 'secondaryOutcomes', 
+          measure: "Percent Change From Baseline in Investigator's Global Assessment (IGA) Score at Weeks 2, 4, 8, and 12",
+          time_frame: 'Baseline; Weeks 2, 4, 8, and 12', 
+          population: false, 
+          description: 'The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema'
+        }
+      ]
+      hash = JSON.parse(File.read('spec/support/json_data/NCT03064438.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(DesignOutcome.mapper(processor)).to eq(expected_data)
+    end
+  end  
+end

--- a/spec/models/design_outcome_spec.rb
+++ b/spec/models/design_outcome_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe DesignOutcome do
 
   describe 'DesignOutcome#mapper' do
-    it 'should have expected primary, secondary, and other design outcomes data' do
+    it 'should return primary, secondary, and other design outcomes data' do
       expected_data = [
         { 
           nct_id: "NCT03064438", 
@@ -90,27 +90,108 @@ RSpec.describe DesignOutcome do
       processor = StudyJsonRecord::ProcessorV2.new(hash)
       expect(DesignOutcome.mapper(processor)).to eq(expected_data)
     end
+    
+    it 'should return primary and secondary design outcomes data and no other design outcomes data' do
+      expected_data = [
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "primaryoutcomes", 
+          measure: "BMI",
+          time_frame: "2 year/end of study", 
+          population: nil,
+          description: nil
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "primaryoutcomes", 
+          measure: "Body Composition",
+          time_frame: "2 year/end of study", 
+          population: nil, 
+          description: "Reporting % of Fat and Lean body mass"
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "primaryoutcomes", 
+          measure: "CRP",
+          time_frame: "2 year/end of study", 
+          population: nil, 
+          description: nil
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Glucose Tolerance",
+          time_frame: "2-year", 
+          population: nil,
+          description: "We completed the OGTT at the 2 year/end of study visit."
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Inflammatory Markers",
+          time_frame: "2 year/end of study", 
+          population: nil,
+          description: nil
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Wt Z Score",
+          time_frame: "2 year/end of study", 
+          population: nil, 
+          description: nil
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "Tanner Stage",
+          time_frame: "2 year/end of study", 
+          population: nil,
+          description: "Puberty scale measuring 1-5, 1 being least development, 5 being most development."
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "FEV 1",
+          time_frame: "2 year/end of study", 
+          population: nil,
+          description: "% of lung function"
+        },
+        { 
+          nct_id: "NCT00763412", 
+          outcome_type: "secondaryoutcomes", 
+          measure: "C-Peptide",
+          time_frame: "2 year", 
+          population: nil, 
+          description: nil
+        }
+      ]
+      hash = JSON.parse(File.read('spec/support/json_data/NCT00763412.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(DesignOutcome.mapper(processor)).to eq(expected_data)  
+    end
+
+    it 'should return primary design outcomes data and no secondary or other design outcomes data' do
+      expected_data = [
+        { 
+          nct_id: "NCT00973089", 
+          outcome_type: "primaryoutcomes", 
+          measure: "The success of the alternative treatment of the deep carious lesion.",
+          time_frame: "Half annually for three years", 
+          population: nil,
+          description: nil
+        }
+      ]
+      hash = JSON.parse(File.read('spec/support/json_data/NCT00973089.json'))
+      processor = StudyJsonRecord::ProcessorV2.new(hash)
+      expect(DesignOutcome.mapper(processor)).to eq(expected_data)
+    end   
 
     it 'should return nil when design outcomes data is empty' do
       hash = JSON.parse(File.read('spec/support/json_data/design_outcome_empty.json'))
       processor = StudyJsonRecord::ProcessorV2.new(hash)
       expect(DesignOutcome.mapper(processor)).to eq(nil)  
     end
-    
-    it 'should have expected primary design outcomes data' do
-      expected_data = [
-        { 
-          nct_id: "NCT", 
-          outcome_type: "primaryoutcomes", 
-          measure: "",
-          time_frame: "", 
-          population: nil, 
-          description: ""
-        }
-      ]
-      hash = JSON.parse(File.read('spec/support/json_data/design_outcome_empty.json'))
-      processor = StudyJsonRecord::ProcessorV2.new(hash)
-      expect(DesignOutcome.mapper(processor)).to eq(expected_data)  
-    end
-  end  
+  end 
+
 end

--- a/spec/support/json_data/NCT00763412.json
+++ b/spec/support/json_data/NCT00763412.json
@@ -1,0 +1,1996 @@
+{
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT00763412",
+  "orgStudyIdInfo": {
+  "id": "05-1109"
+  },
+  "secondaryIdInfos": [
+  {
+  "id": "P60DK020579",
+  "type": "NIH",
+  "link": "https://reporter.nih.gov/quickSearch/P60DK020579"
+  }
+  ],
+  "organization": {
+  "fullName": "Arbelaez, Ana Maria",
+  "class": "INDIV"
+  },
+  "briefTitle": "Pilot and Feasibility Study for the Treatment of Pre-diabetes in Patients With Cystic Fibrosis",
+  "officialTitle": "Pilot and Feasibility Study for the Treatment of Pre-diabetes in Patients With Cystic Fibrosis"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2017-05",
+  "overallStatus": "COMPLETED",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2006-11"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2013-01",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2013-01",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2008-09-29",
+  "studyFirstSubmitQcDate": "2008-09-30",
+  "studyFirstPostDateStruct": {
+  "date": "2008-10-01",
+  "type": "ESTIMATED"
+  },
+  "resultsFirstSubmitDate": "2016-07-11",
+  "resultsFirstSubmitQcDate": "2017-05-03",
+  "resultsFirstPostDateStruct": {
+  "date": "2017-06-05",
+  "type": "ACTUAL"
+  },
+  "lastUpdateSubmitDate": "2017-05-03",
+  "lastUpdatePostDateStruct": {
+  "date": "2017-06-05",
+  "type": "ACTUAL"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "PRINCIPAL_INVESTIGATOR",
+  "investigatorFullName": "Ana Maria Arbelaez",
+  "investigatorTitle": "Assistant Professor in Pediatrics",
+  "investigatorAffiliation": "Arbelaez, Ana Maria"
+  },
+  "leadSponsor": {
+  "name": "Arbelaez, Ana Maria",
+  "class": "INDIV"
+  },
+  "collaborators": [
+  {
+  "name": "Washington University School of Medicine",
+  "class": "OTHER"
+  },
+  {
+  "name": "National Institutes of Health (NIH)",
+  "class": "NIH"
+  },
+  {
+  "name": "Novo Nordisk A/S",
+  "class": "INDUSTRY"
+  },
+  {
+  "name": "National Institute of Diabetes and Digestive and Kidney Diseases (NIDDK)",
+  "class": "NIH"
+  }
+  ]
+  },
+  "oversightModule": {
+  "oversightHasDmc": true,
+  "isFdaRegulatedDrug": true,
+  "isFdaRegulatedDevice": false
+  },
+  "descriptionModule": {
+  "briefSummary": "The purpose of this study is to provide the necessary data and experience to design a larger, full scale clinical trial to determine if a certain medicine (repaglinide), which increases the amount of insulin secreted by the pancreas, can improve the nutritional status and pulmonary function of adolescents and young adults with cystic fibrosis and prediabetes by improving blood glucose control. The investigators are also trying to determine the relationship between systemic inflammatory factors and glucose impairment.",
+  "detailedDescription": "As people with Cystic Fibrosis (CF) are living well into adulthood new complications are arising. CF-Related Diabetes (CFRD) has emerged as a major complication. Years prior to the diagnosis of CFRD, patients have decreasing insulin secretion, glucose intolerance, deteriorating pulmonary function, and nutritional impairment. There are no current standard recommendations for the treatment of CF patients with prediabetes, and there is little evidence that treatment of this prediabetic state in CF patients will prevent the deterioration of the lung function, nutritional status and potentially slow the progression to manifest CFRD.\n\nTo determine the feasibility of testing this hypothesis, we will perform a pilot, double-blinded, randomized controlled trial in 20 CF pancreatic insufficient patients ages of 12 to 24 years old with impaired glucose tolerance test (IGT) or CFRD without fasting hyperglycemia (CFRD-No FH) and assign them to either placebo or Repaglinide 0.5 mg PO 3 - 4 times a day before meals for two years. Patients will monitor their blood glucose daily and will be followed every 3 months for 2 years to determine changes in nutritional status by BMI and DEXA, lung function tests, frequency of hospitalizations, antibiotic courses, and degree of glucose tolerance, insulin secretion and insulin sensitivity.\n\nIn addition, based on the evidence of increased inflammation in type 2 diabetes, correlation of systemic inflammatory response at different degrees of glucose tolerance and after treatment, will be assessed in these subjects, as well as in another 20 CF pancreatic insufficient matched patients with normal glucose tolerance who will be studied once without intervention"
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Cystic Fibrosis Related Diabetes",
+  "Pancreatic Insufficiency"
+  ],
+  "keywords": [
+  "Cystic Fibrosis",
+  "Diabetes",
+  "Cystic Fibrosis Related Diabetes",
+  "Pre-diabetes",
+  "oral hypoglycemic agents",
+  "Repaglinide",
+  "treatment",
+  "inflammatory markers",
+  "Lung function",
+  "nutrition"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "NA"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "primaryPurpose": "OTHER",
+  "maskingInfo": {
+  "masking": "QUADRUPLE",
+  "whoMasked": [
+  "PARTICIPANT",
+  "CARE_PROVIDER",
+  "INVESTIGATOR",
+  "OUTCOMES_ASSESSOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 31,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "1 Placebo",
+  "type": "PLACEBO_COMPARATOR",
+  "description": "1 pill before each meal 3-4 times a day for 2 years. All subjects had abnormal glucose tolerance. Subjects were randomized to placebo or drug.",
+  "interventionNames": [
+  "Drug: placebo"
+  ]
+  },
+  {
+  "label": "2. repaglinide",
+  "type": "EXPERIMENTAL",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years. All subjects had abnormal glucose tolerance.Subjects were randomized to placebo or drug.",
+  "interventionNames": [
+  "Drug: repaglinide"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "DRUG",
+  "name": "placebo",
+  "description": "CF pancreatic insufficient patients with impaired glucose tolerance (IGT) or CFRD without fasting hyperglycemia (CFRD-No FH) by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years.",
+  "armGroupLabels": [
+  "1 Placebo"
+  ]
+  },
+  {
+  "type": "DRUG",
+  "name": "repaglinide",
+  "description": "CF pancreatic insufficient patients with impaired glucose tolerance (IGT) or CFRD without fasting hyperglycemia (CFRD-No FH) by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years.",
+  "armGroupLabels": [
+  "2. repaglinide"
+  ],
+  "otherNames": [
+  "Prandin"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  "primaryOutcomes": [
+  {
+  "measure": "BMI",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "Body Composition",
+  "description": "Reporting % of Fat and Lean body mass",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "CRP",
+  "timeFrame": "2 year/end of study"
+  }
+  ],
+  "secondaryOutcomes": [
+  {
+  "measure": "Glucose Tolerance",
+  "description": "We completed the OGTT at the 2 year/end of study visit.",
+  "timeFrame": "2-year"
+  },
+  {
+  "measure": "Inflammatory Markers",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "Wt Z Score",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "Tanner Stage",
+  "description": "Puberty scale measuring 1-5, 1 being least development, 5 being most development.",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "FEV 1",
+  "description": "% of lung function",
+  "timeFrame": "2 year/end of study"
+  },
+  {
+  "measure": "C-Peptide",
+  "timeFrame": "2 year"
+  }
+  ]
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Inclusion Criteria:\n\n* Male or females 12 -24 years old\n* Diagnosis of Cystic Fibrosis by sweat test with exocrine pancreatic insufficiency\n* Must have a glucose pattern by Oral Glucose Tolerance Test with fasting blood glucose \\<126 mg/dl and 2 hour: 140 - 199 mg/dl or \\>200 mg/dl.\n* Weight must be stable within 5% for 3 months prior to initiation visit\n* Must be able to reproducibly perform spirometry based on American Thoracic Society guidelines\n\nExclusion Criteria:\n\n* Patients receiving growth hormone therapy or taking insulin\n* Patients with evidence of liver dysfunction\n* Patients who are status-post lung or liver transplantation\n* Patients who have received systemic steroids for more than 28 days during the 6 months prior to the study\n* Patients with active ABPA on steroids\n* Patients taking medications that affect glucose metabolism or contraindicated with repaglinide",
+  "healthyVolunteers": false,
+  "sex": "ALL",
+  "minimumAge": "12 Years",
+  "maximumAge": "24 Years",
+  "stdAges": [
+  "CHILD",
+  "ADULT"
+  ]
+  },
+  "contactsLocationsModule": {
+  "overallOfficials": [
+  {
+  "name": "Neil H White, M.D.",
+  "affiliation": "Washington University School of Medicine",
+  "role": "STUDY_CHAIR"
+  }
+  ],
+  "locations": [
+  {
+  "facility": "Washington University School of Medicine",
+  "city": "Saint Louis",
+  "state": "Missouri",
+  "zip": "63110",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 38.62727,
+  "lon": -90.19789
+  }
+  }
+  ]
+  },
+  "ipdSharingStatementModule": {
+  "ipdSharing": "UNDECIDED",
+  "description": "The outcome was inconclusive for this hypothesis, but the data may be valuable in future research. We are not currently sharing data from this project."
+  }
+  },
+  "resultsSection": {
+  "participantFlowModule": {
+  "groups": [
+  {
+  "id": "FG000",
+  "title": "Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "FG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "periods": [
+  {
+  "title": "Overall Study",
+  "milestones": [
+  {
+  "type": "STARTED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "8"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "8"
+  }
+  ]
+  },
+  {
+  "type": "COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "4"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "4"
+  }
+  ]
+  },
+  {
+  "type": "NOT COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "4"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "4"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "baselineCharacteristicsModule": {
+  "populationDescription": "Patients attended the Washington University CF Clinics between 2006 and 2008.",
+  "groups": [
+  {
+  "id": "BG000",
+  "title": "Patients Who Received Placebo",
+  "description": "All participants were receiving ADEK vitamins and pancreatic enzyme replacement. Patients were required to be clinically stable, without evidence of deterioration from previous pulmonary function tests (PFTs) for 3-months prior to the study and without CF exacerbation or hospitalization for 2-months prior to the study. Additionally, patients were required to have maintained stable weight within 5% variance for 3-months prior to participation. Exclusion criteria included fasting blood glucose levels \\>126 mg/dL on study day, IV antibiotic or systemic steroid use within two months, oral corticosteroid usage for more than 28-days over the past 6-months, history of lung or liver transplant, elevated transaminases, allergic bronchopulmonary aspergillosis, or the inability to perform spirometry."
+  },
+  {
+  "id": "BG001",
+  "title": "Patients Who Received Repaglinide",
+  "description": "All participants were receiving ADEK vitamins and pancreatic enzyme replacement. Patients were required to be clinically stable, without evidence of deterioration from previous pulmonary function tests (PFTs) for 3-months prior to the study and without CF exacerbation or hospitalization for 2-months prior to the study. Additionally, patients were required to have maintained stable weight within 5% variance for 3-months prior to participation. Exclusion criteria included fasting blood glucose levels \\>126 mg/dL on study day, IV antibiotic or systemic steroid use within two months, oral corticosteroid usage for more than 28-days over the past 6-months, history of lung or liver transplant, elevated transaminases, allergic bronchopulmonary aspergillosis, or the inability to perform spirometry."
+  },
+  {
+  "id": "BG002",
+  "title": "Total",
+  "description": "Total of all reporting groups"
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "4"
+  },
+  {
+  "groupId": "BG001",
+  "value": "4"
+  },
+  {
+  "groupId": "BG002",
+  "value": "8"
+  }
+  ]
+  }
+  ],
+  "measures": [
+  {
+  "title": "Age, Categorical",
+  "description": "Patients attended the Washington University CF Clinics between 2006 and 2008.",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "<=18 years",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "3"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "6"
+  }
+  ]
+  },
+  {
+  "title": "Between 18 and 65 years",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "2"
+  }
+  ]
+  },
+  {
+  "title": ">=65 years",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Age, Continuous",
+  "paramType": "MEDIAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "years",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "16",
+  "lowerLimit": "12",
+  "upperLimit": "18"
+  },
+  {
+  "groupId": "BG001",
+  "value": "15",
+  "lowerLimit": "12",
+  "upperLimit": "22"
+  },
+  {
+  "groupId": "BG002",
+  "value": "15.5",
+  "lowerLimit": "12",
+  "upperLimit": "22"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Sex: Female, Male",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Female",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "2"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Male",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "2"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Region of Enrollment",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "participants",
+  "classes": [
+  {
+  "title": "United States",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "8"
+  },
+  {
+  "groupId": "BG001",
+  "value": "8"
+  },
+  {
+  "groupId": "BG002",
+  "value": "16"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "BMI",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "Kg/m^2",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "19.45",
+  "lowerLimit": "14.55",
+  "upperLimit": "22.96"
+  },
+  {
+  "groupId": "BG001",
+  "value": "18.38",
+  "lowerLimit": "16.78",
+  "upperLimit": "20.3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "18.94",
+  "lowerLimit": "14.55",
+  "upperLimit": "22.96"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Wt Z score",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "Z score",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "-1.11",
+  "lowerLimit": "-1.84",
+  "upperLimit": "0.33"
+  },
+  {
+  "groupId": "BG001",
+  "value": "-0.29",
+  "lowerLimit": "-0.75",
+  "upperLimit": "0.19"
+  },
+  {
+  "groupId": "BG002",
+  "value": "-0.7",
+  "lowerLimit": "-1.84",
+  "upperLimit": ".33"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Fat %",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "% Fat mass",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "20.34",
+  "lowerLimit": "7.36",
+  "upperLimit": "38.74"
+  },
+  {
+  "groupId": "BG001",
+  "value": "22.06",
+  "lowerLimit": "9.76",
+  "upperLimit": "28.81"
+  },
+  {
+  "groupId": "BG002",
+  "value": "21.2",
+  "lowerLimit": "7.36",
+  "upperLimit": "38.74"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Lean %",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "% Lean mass",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "76.71",
+  "lowerLimit": "58.6",
+  "upperLimit": "89.67"
+  },
+  {
+  "groupId": "BG001",
+  "value": "75",
+  "lowerLimit": "68.22",
+  "upperLimit": "87.11"
+  },
+  {
+  "groupId": "BG002",
+  "value": "75.9",
+  "lowerLimit": "58.6",
+  "upperLimit": "89.67"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Tanner stage",
+  "description": "This is a measurement of puberty development. This is a 1-5 scale describing 1 as the least developed and 5 as the most developed in puberty.",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "units on a scale",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "3.75",
+  "lowerLimit": "2",
+  "upperLimit": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3.25",
+  "lowerLimit": "1",
+  "upperLimit": "5"
+  },
+  {
+  "groupId": "BG002",
+  "value": "3.5",
+  "lowerLimit": "1",
+  "upperLimit": "5"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "FEV 1",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "% of lung function",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "97.75",
+  "lowerLimit": "92",
+  "upperLimit": "121"
+  },
+  {
+  "groupId": "BG001",
+  "value": "92.75",
+  "lowerLimit": "70",
+  "upperLimit": "105"
+  },
+  {
+  "groupId": "BG002",
+  "value": "95.25",
+  "lowerLimit": "70",
+  "upperLimit": "121"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Fasting Glucose",
+  "description": "This was the baseline glucose in a 2 hour oral glucose tolerance test. (OGTT)",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "mg/dl",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "99.1",
+  "lowerLimit": "87",
+  "upperLimit": "114.5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "100",
+  "lowerLimit": "94",
+  "upperLimit": "106"
+  },
+  {
+  "groupId": "BG002",
+  "value": "99.6",
+  "lowerLimit": "87",
+  "upperLimit": "114.5"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "2 hour glucose",
+  "description": "Final glucose sample in a 2 hour OGTT.",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "mg/dl",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "182.4",
+  "lowerLimit": "144",
+  "upperLimit": "218.5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "183",
+  "lowerLimit": "140",
+  "upperLimit": "206"
+  },
+  {
+  "groupId": "BG002",
+  "value": "182.7",
+  "lowerLimit": "140",
+  "upperLimit": "218.5"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Fasting C-Peptide",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "mg/dl",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1.2",
+  "lowerLimit": "0.6",
+  "upperLimit": "2.1"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1.7",
+  "lowerLimit": "1.0",
+  "upperLimit": "3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "1.45",
+  "lowerLimit": "0.6",
+  "upperLimit": "3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "2 hour c-peptide",
+  "description": "final c-peptide measurement at the end of 2 hour OGTT.",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "mg/dl",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "9.7",
+  "lowerLimit": "6",
+  "upperLimit": "15.5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "9.5",
+  "lowerLimit": "5",
+  "upperLimit": "12.6"
+  },
+  {
+  "groupId": "BG002",
+  "value": "9.6",
+  "lowerLimit": "5",
+  "upperLimit": "15.5"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Inflammatory marker",
+  "description": "baseline values collected during a 2 hour OGTT.",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "pg/ml",
+  "classes": [
+  {
+  "title": "IL1",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0.1",
+  "lowerLimit": "0.1",
+  "upperLimit": "1.9"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0.9",
+  "lowerLimit": ".01",
+  "upperLimit": "1.7"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0.5",
+  "lowerLimit": "0.1",
+  "upperLimit": "1.9"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "IL6",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "8.3",
+  "lowerLimit": "1.5",
+  "upperLimit": "26.4"
+  },
+  {
+  "groupId": "BG001",
+  "value": "12.6",
+  "lowerLimit": "3.7",
+  "upperLimit": "33.8"
+  },
+  {
+  "groupId": "BG002",
+  "value": "10.5",
+  "lowerLimit": "1.5",
+  "upperLimit": "33.8"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "IL8",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "7",
+  "lowerLimit": "2.7",
+  "upperLimit": "17.8"
+  },
+  {
+  "groupId": "BG001",
+  "value": "8.5",
+  "lowerLimit": "4.6",
+  "upperLimit": "13.6"
+  },
+  {
+  "groupId": "BG002",
+  "value": "7.75",
+  "lowerLimit": "2.7",
+  "upperLimit": "17.8"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "TNF Alpha",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "7.3",
+  "lowerLimit": "5.2",
+  "upperLimit": "7.3"
+  },
+  {
+  "groupId": "BG001",
+  "value": "4.5",
+  "lowerLimit": "2.5",
+  "upperLimit": "6.4"
+  },
+  {
+  "groupId": "BG002",
+  "value": "5.9",
+  "lowerLimit": "2.5",
+  "upperLimit": "7.3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "CRP",
+  "description": "inflammatory marker",
+  "paramType": "MEAN",
+  "dispersionType": "FULL_RANGE",
+  "unitOfMeasure": "mg/L",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1.8",
+  "lowerLimit": "0.2",
+  "upperLimit": "2.5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "2.1",
+  "lowerLimit": "0.8",
+  "upperLimit": "3.3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "1.95",
+  "lowerLimit": "0.2",
+  "upperLimit": "3.3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "outcomeMeasuresModule": {
+  "outcomeMeasures": [
+  {
+  "type": "PRIMARY",
+  "title": "BMI",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "Kg/m^2",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "19.63",
+  "lowerLimit": "15.56",
+  "upperLimit": "22.64"
+  },
+  {
+  "groupId": "OG001",
+  "value": "21.19",
+  "lowerLimit": "20.78",
+  "upperLimit": "21.8"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "PRIMARY",
+  "title": "Body Composition",
+  "description": "Reporting % of Fat and Lean body mass",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "% body mass",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Fat",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "19.82",
+  "lowerLimit": "12",
+  "upperLimit": "37.8"
+  },
+  {
+  "groupId": "OG001",
+  "value": "26.21",
+  "lowerLimit": "8.78",
+  "upperLimit": "34.26"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Lean",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "77.15",
+  "lowerLimit": "59.54",
+  "upperLimit": "87.84"
+  },
+  {
+  "groupId": "OG001",
+  "value": "70.83",
+  "lowerLimit": "62.82",
+  "upperLimit": "87.8"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "PRIMARY",
+  "title": "CRP",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "mg/L",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "9.6",
+  "lowerLimit": "0.7",
+  "upperLimit": "27.5"
+  },
+  {
+  "groupId": "OG001",
+  "value": "2",
+  "lowerLimit": "0.6",
+  "upperLimit": "3.7"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Glucose Tolerance",
+  "description": "We completed the OGTT at the 2 year/end of study visit.",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "mg/dl",
+  "timeFrame": "2-year",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "fasting glucose",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "101.5",
+  "lowerLimit": "91",
+  "upperLimit": "121"
+  },
+  {
+  "groupId": "OG001",
+  "value": "94.5",
+  "lowerLimit": "85",
+  "upperLimit": "108"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "2 hour glucose",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "185.75",
+  "lowerLimit": "145",
+  "upperLimit": "258"
+  },
+  {
+  "groupId": "OG001",
+  "value": "184",
+  "lowerLimit": "123",
+  "upperLimit": "266"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Inflammatory Markers",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "pg/ml",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "IL1",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.14",
+  "lowerLimit": "0.13",
+  "upperLimit": "0.17"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0.34",
+  "lowerLimit": "0.13",
+  "upperLimit": "1"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "IL6",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "10.4",
+  "lowerLimit": "0.54",
+  "upperLimit": "28.6"
+  },
+  {
+  "groupId": "OG001",
+  "value": "6",
+  "lowerLimit": "2.2",
+  "upperLimit": "11.9"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "IL8",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "5.8",
+  "lowerLimit": "3.59",
+  "upperLimit": "10.79"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5.2",
+  "lowerLimit": "3.1",
+  "upperLimit": "8.33"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "TNF alpha",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "5.1",
+  "lowerLimit": "2.05",
+  "upperLimit": "7.5"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3.6",
+  "lowerLimit": "1.99",
+  "upperLimit": "5.3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Wt Z Score",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "Z score",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.21",
+  "lowerLimit": "-1.94",
+  "upperLimit": "0.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.26",
+  "lowerLimit": "-0.31",
+  "upperLimit": "0.72"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Tanner Stage",
+  "description": "Puberty scale measuring 1-5, 1 being least development, 5 being most development.",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "units on a scale",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "4.25",
+  "lowerLimit": "4",
+  "upperLimit": "5"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5",
+  "lowerLimit": "5",
+  "upperLimit": "5"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "FEV 1",
+  "description": "% of lung function",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "% lung function",
+  "timeFrame": "2 year/end of study",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "90.5",
+  "lowerLimit": "71",
+  "upperLimit": "99"
+  },
+  {
+  "groupId": "OG001",
+  "value": "91.5",
+  "lowerLimit": "74",
+  "upperLimit": "108"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "C-Peptide",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Full Range",
+  "unitOfMeasure": "pg/ml",
+  "timeFrame": "2 year",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "1 Placebo",
+  "description": "1 pill before each meal 3-4 times a day for 2 years.\n\nplacebo: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with placebo by taking 1 pill before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  },
+  {
+  "id": "OG001",
+  "title": "2. Repaglinide",
+  "description": "repaglinide 0.5 mg before each meal 3-4 times a day for 2 years.\n\nrepaglinide: CF pancreatic insufficient patients with prediabetes by OGTT will be treated with repaglinide 0.5 mg before each meal that contains more than 20 grams of carbohydrate 3-4 times a day for 2 years."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "4"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "fasting",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1.5",
+  "lowerLimit": "0.8",
+  "upperLimit": "2.3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1.6",
+  "lowerLimit": "0.6",
+  "upperLimit": "2.5"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "2 hour",
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "7.5",
+  "lowerLimit": "5",
+  "upperLimit": "8.7"
+  },
+  {
+  "groupId": "OG001",
+  "value": "7.7",
+  "lowerLimit": "4.2",
+  "upperLimit": "11.9"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "adverseEventsModule": {
+  "frequencyThreshold": "0",
+  "timeFrame": "This pilot study was designed to collect data over a 2 year time period.",
+  "description": "Glucose diaries, and food diaries were reviewed, and safety labs were collected at each visit. Physical assessments by the PI were completed as well.",
+  "eventGroups": [
+  {
+  "id": "EG000",
+  "title": "Placebo",
+  "description": "Placebo group of CF pancreatic insufficient patients ages 12-24 years old with impaired glucose tolerance test (IGT) or CFRD without fasting hyperglycemia (CFRD-No FH).",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 8,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 8,
+  "otherNumAffected": 0,
+  "otherNumAtRisk": 8
+  },
+  {
+  "id": "EG001",
+  "title": "Repaglinide",
+  "description": "Repaglinide intervention group of CF pancreatic insufficient patients ages 12-24 years old with impaired glucose tolerance test (IGT) or CFRD without fasting hyperglycemia (CFRD-No FH).",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 8,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 8,
+  "otherNumAffected": 0,
+  "otherNumAtRisk": 8
+  }
+  ]
+  },
+  "moreInfoModule": {
+  "limitationsAndCaveats": {
+  "description": "A limitation of the study was the very small sample size."
+  },
+  "certainAgreement": {
+  "piSponsorEmployee": false,
+  "restrictiveAgreement": false
+  },
+  "pointOfContact": {
+  "title": "Ana Maria Arbelaez",
+  "organization": "Washington University in St Louis",
+  "email": "arbelaez_a@kids.wustl.edu",
+  "phone": "314-286-1138"
+  }
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2024-01-03",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000003550",
+  "term": "Cystic Fibrosis"
+  },
+  {
+  "id": "D000010188",
+  "term": "Exocrine Pancreatic Insufficiency"
+  },
+  {
+  "id": "D000003920",
+  "term": "Diabetes Mellitus"
+  },
+  {
+  "id": "D000011236",
+  "term": "Prediabetic State"
+  },
+  {
+  "id": "D000018149",
+  "term": "Glucose Intolerance"
+  },
+  {
+  "id": "D000005355",
+  "term": "Fibrosis"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000044882",
+  "term": "Glucose Metabolism Disorders"
+  },
+  {
+  "id": "D000008659",
+  "term": "Metabolic Diseases"
+  },
+  {
+  "id": "D000004700",
+  "term": "Endocrine System Diseases"
+  },
+  {
+  "id": "D000010335",
+  "term": "Pathologic Processes"
+  },
+  {
+  "id": "D000010182",
+  "term": "Pancreatic Diseases"
+  },
+  {
+  "id": "D000004066",
+  "term": "Digestive System Diseases"
+  },
+  {
+  "id": "D000008171",
+  "term": "Lung Diseases"
+  },
+  {
+  "id": "D000012140",
+  "term": "Respiratory Tract Diseases"
+  },
+  {
+  "id": "D000030342",
+  "term": "Genetic Diseases, Inborn"
+  },
+  {
+  "id": "D000007232",
+  "term": "Infant, Newborn, Diseases"
+  },
+  {
+  "id": "D000006943",
+  "term": "Hyperglycemia"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M6445",
+  "name": "Cystic Fibrosis",
+  "asFound": "Cystic Fibrosis",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M8175",
+  "name": "Fibrosis",
+  "asFound": "Fibrosis",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M6805",
+  "name": "Diabetes Mellitus",
+  "asFound": "Diabetes",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M13807",
+  "name": "Prediabetic State",
+  "asFound": "Pre-diabetes",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M19985",
+  "name": "Glucose Intolerance",
+  "asFound": "Pre-diabetes",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M12798",
+  "name": "Exocrine Pancreatic Insufficiency",
+  "asFound": "Pancreatic Insufficiency",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M11329",
+  "name": "Metabolic Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M25093",
+  "name": "Glucose Metabolism Disorders",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M7552",
+  "name": "Endocrine System Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M12792",
+  "name": "Pancreatic Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M8573",
+  "name": "Gastrointestinal Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M6945",
+  "name": "Digestive System Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M10858",
+  "name": "Lung Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M14667",
+  "name": "Respiratory Tract Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M23376",
+  "name": "Genetic Diseases, Inborn",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M9966",
+  "name": "Infant, Newborn, Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M9684",
+  "name": "Hyperglycemia",
+  "relevance": "LOW"
+  },
+  {
+  "id": "T1710",
+  "name": "Cystic Fibrosis",
+  "asFound": "Cystic Fibrosis",
+  "relevance": "HIGH"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BC06",
+  "name": "Digestive System Diseases"
+  },
+  {
+  "abbrev": "BC08",
+  "name": "Respiratory Tract (Lung and Bronchial) Diseases"
+  },
+  {
+  "abbrev": "BC16",
+  "name": "Diseases and Abnormalities at or Before Birth"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  },
+  {
+  "abbrev": "BC23",
+  "name": "Symptoms and General Pathology"
+  },
+  {
+  "abbrev": "BC18",
+  "name": "Nutritional and Metabolic Diseases"
+  },
+  {
+  "abbrev": "BC19",
+  "name": "Gland and Hormone Related Diseases"
+  },
+  {
+  "abbrev": "Rare",
+  "name": "Rare Diseases"
+  }
+  ]
+  },
+  "interventionBrowseModule": {
+  "meshes": [
+  {
+  "id": "C000072379",
+  "term": "Repaglinide"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000007004",
+  "term": "Hypoglycemic Agents"
+  },
+  {
+  "id": "D000045505",
+  "term": "Physiological Effects of Drugs"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M9744",
+  "name": "Hypoglycemic Agents",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M352694",
+  "name": "Repaglinide",
+  "asFound": "Biospecimen Collection",
+  "relevance": "HIGH"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "Hypo",
+  "name": "Hypoglycemic Agents"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Drugs and Chemicals"
+  }
+  ]
+  }
+  },
+  "hasResults": true
+  }

--- a/spec/support/json_data/NCT00973089.json
+++ b/spec/support/json_data/NCT00973089.json
@@ -1,0 +1,233 @@
+{
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT00973089",
+  "orgStudyIdInfo": {
+  "id": "LSA001-HMO-CTIL"
+  },
+  "organization": {
+  "fullName": "Hadassah Medical Organization",
+  "class": "OTHER"
+  },
+  "briefTitle": "Alternative Treatment of Deep Carious Lesions Based on Biological Evidences",
+  "officialTitle": "Alternative Treatment of Deep Carious Lesions Based on Biological Evidences"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2015-08",
+  "overallStatus": "WITHDRAWN",
+  "whyStopped": "recruiting or enrolling participants has halted prematurely and will not resume",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2010-05"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2015-03",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2015-03",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2009-09-06",
+  "studyFirstSubmitQcDate": "2009-09-06",
+  "studyFirstPostDateStruct": {
+  "date": "2009-09-09",
+  "type": "ESTIMATED"
+  },
+  "lastUpdateSubmitDate": "2015-08-18",
+  "lastUpdatePostDateStruct": {
+  "date": "2015-08-19",
+  "type": "ESTIMATED"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "PRINCIPAL_INVESTIGATOR",
+  "investigatorFullName": "Moti Moskovitz",
+  "investigatorTitle": "Clinical Senior Lecturer",
+  "investigatorAffiliation": "Hadassah Medical Organization"
+  },
+  "leadSponsor": {
+  "name": "Hadassah Medical Organization",
+  "class": "OTHER"
+  }
+  },
+  "oversightModule": {
+  "oversightHasDmc": true
+  },
+  "descriptionModule": {
+  "briefSummary": "The purpose of this study is to evaluate the success rate of alternative treatment of deep carious lesions in asymptomatic primary teeth with no clinical nor radiographic signs of pulpal inflammation. The treatment includes leaving a thin layer of caries that is present near the pulp chamber and includes liner placement and tooth sealing. This alternative treatment is to be compared with the treatment provided today to these teeth, which includes complete removal of caries and probably includes pulpotomy and wide preparation of the tooth. The study also evaluates the cost-effectiveness of both methods of treatment of deep carious lesions.",
+  "detailedDescription": "The treatment provided today for deep carious lesions in deciduous teeth is complete removal of the soft caries, that can lead to a wide preparation and need of tooth pulpotomy if the caries reaches to the pulp chamber, even if the tooth is asymptomatic and shows no signs of pulpal inflammation (neither clinically nor radiographically). According to a number of recent evidence based researches, and only in selected cases, dentists were able to preserve the vitality of the pulp without complete removal of the caries present near the pulp chamber. A thin layer of caries near the pulp chamber is left, and a liner is placed (conservative treatment). The carious process is stopped when the tooth is sealed, and thus the tooth is saved without engaging with pulpotomy and wide preparation of the tooth. The purpose of this study is to evaluate the success rate of the conservative treatment of deep carious lesions versus the treatment provided today that includes complete removal of caries and probably includes pulpotomy and wide preparation of the tooth. The study also evaluates the cost-effectiveness of both methods of treatment of deep carious lesions."
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Caries, Dental"
+  ],
+  "keywords": [
+  "Primary tooth",
+  "Caries, Dental",
+  "Alternative treatment"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "NA"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "primaryPurpose": "TREATMENT",
+  "maskingInfo": {
+  "masking": "SINGLE",
+  "whoMasked": [
+  "INVESTIGATOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 0,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "Complete caries removal",
+  "type": "NO_INTERVENTION",
+  "description": "Control group"
+  },
+  {
+  "label": "Incomplete caries removal",
+  "type": "OTHER",
+  "description": "Test group",
+  "interventionNames": [
+  "Other: Incomplete caries removal in primary teeth"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "OTHER",
+  "name": "Incomplete caries removal in primary teeth",
+  "description": "Comparison between the success rate and cost-effectiveness of complete caries removal in treatment of deep carious lesions that might include wide preparations and involve pulpotomy versus incomplete removal of caries and avoiding pulp treatment.",
+  "armGroupLabels": [
+  "Incomplete caries removal"
+  ],
+  "otherNames": [
+  "Indirect pulp capping"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  "primaryOutcomes": [
+  {
+  "measure": "The success of the alternative treatment of the deep carious lesion.",
+  "timeFrame": "Half annually for three years"
+  }
+  ]
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Inclusion Criteria:\n\n* Healthy children\n* Patient's age is 5-8 years old at the time of the treatment\n* Primary molars presenting with deep carious lesions\n* Carious lesion reaching the inner half of the dentin,with absence of periapical or interradicular alterations as detected by radiographic examination.\n* Absence of spontaneous pain\n\nExclusion Criteria:\n\n* Subjects that are not ASA I\n* Lack of cooperation\n* Clinical or radiographic signs of pathology",
+  "healthyVolunteers": true,
+  "sex": "ALL",
+  "minimumAge": "5 Years",
+  "maximumAge": "8 Years",
+  "stdAges": [
+  "CHILD"
+  ]
+  },
+  "contactsLocationsModule": {
+  "locations": [
+  {
+  "facility": "Hadassah Medical Organization",
+  "city": "Jerusalem",
+  "country": "Israel",
+  "geoPoint": {
+  "lat": 31.76904,
+  "lon": 35.21633
+  }
+  }
+  ]
+  },
+  "referencesModule": {
+  "references": [
+  {
+  "pmid": "18519994",
+  "type": "BACKGROUND",
+  "citation": "Thompson V, Craig RG, Curro FA, Green WS, Ship JA. Treatment of deep carious lesions by complete excavation or partial removal: a critical review. J Am Dent Assoc. 2008 Jun;139(6):705-12. doi: 10.14219/jada.archive.2008.0252."
+  }
+  ]
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2024-01-22",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000003731",
+  "term": "Dental Caries"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000017001",
+  "term": "Tooth Demineralization"
+  },
+  {
+  "id": "D000014076",
+  "term": "Tooth Diseases"
+  },
+  {
+  "id": "D000009057",
+  "term": "Stomatognathic Diseases"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M6618",
+  "name": "Dental Caries",
+  "asFound": "Caries,Dental",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M19029",
+  "name": "Tooth Demineralization",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M16521",
+  "name": "Tooth Diseases",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M11707",
+  "name": "Stomatognathic Diseases",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BC07",
+  "name": "Mouth and Tooth Diseases"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  }
+  ]
+  }
+  },
+  "hasResults": false
+  }

--- a/spec/support/json_data/NCT03064438.json
+++ b/spec/support/json_data/NCT03064438.json
@@ -1,0 +1,3034 @@
+{
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT03064438",
+  "orgStudyIdInfo": {
+  "id": "ACU-D1"
+  },
+  "organization": {
+  "fullName": "Accuitis, Inc.",
+  "class": "INDUSTRY"
+  },
+  "briefTitle": "Safety and Efficacy of ACU-D1 in the Treatment of Acne Rosacea",
+  "officialTitle": "A RANDOMIZED, DOUBLE-BLIND, VEHICLE CONTROLLED, PROOF-OF CONCEPT STUDY OF THE SAFETY AND EFFICACY OF ACU-D1 OINTMENT IN SUBJECTS WITH ACNE ROSACEA"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2021-08",
+  "overallStatus": "COMPLETED",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2017-11-28",
+  "type": "ACTUAL"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2018-06-05",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2018-06-18",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2017-02-22",
+  "studyFirstSubmitQcDate": "2017-02-24",
+  "studyFirstPostDateStruct": {
+  "date": "2017-02-27",
+  "type": "ACTUAL"
+  },
+  "resultsFirstSubmitDate": "2021-08-17",
+  "resultsFirstSubmitQcDate": "2021-08-17",
+  "resultsFirstPostDateStruct": {
+  "date": "2021-08-23",
+  "type": "ACTUAL"
+  },
+  "lastUpdateSubmitDate": "2021-08-17",
+  "lastUpdatePostDateStruct": {
+  "date": "2021-08-23",
+  "type": "ACTUAL"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "SPONSOR"
+  },
+  "leadSponsor": {
+  "name": "Accuitis, Inc.",
+  "class": "INDUSTRY"
+  }
+  },
+  "oversightModule": {
+  "oversightHasDmc": false,
+  "isFdaRegulatedDrug": true,
+  "isFdaRegulatedDevice": false,
+  "isUsExport": false,
+  "fdaaa801Violation": true
+  },
+  "descriptionModule": {
+  "briefSummary": "The study evaluated the safety, tolerability, and efficacy of ACCU-D1 when applied twice daily for 12 weeks in adult participants with moderate to severe acne rosacea. Two-third of the participants received ACCU-D1 while one-third of the participants received vehicle control."
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Acne Rosacea"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "PHASE2"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "primaryPurpose": "TREATMENT",
+  "maskingInfo": {
+  "masking": "DOUBLE",
+  "whoMasked": [
+  "PARTICIPANT",
+  "INVESTIGATOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 40,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "ACU-D1 Ointment",
+  "type": "EXPERIMENTAL",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks.",
+  "interventionNames": [
+  "Drug: ACCU-D1"
+  ]
+  },
+  {
+  "label": "ACU-D1 Ointment Vehicle",
+  "type": "PLACEBO_COMPARATOR",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks.",
+  "interventionNames": [
+  "Drug: Vehicle"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "DRUG",
+  "name": "ACCU-D1",
+  "description": "ACCU-D1",
+  "armGroupLabels": [
+  "ACU-D1 Ointment"
+  ]
+  },
+  {
+  "type": "DRUG",
+  "name": "Vehicle",
+  "description": "Placebo Comparator",
+  "armGroupLabels": [
+  "ACU-D1 Ointment Vehicle"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  "primaryOutcomes": [
+  {
+  "measure": "Change From Baseline in Total Lesion Count at Week 12",
+  "description": "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter.",
+  "timeFrame": "Baseline, Week 12"
+  }
+  ],
+  "secondaryOutcomes": [
+  {
+  "measure": "Percent Change From Baseline in Investigator's Global Assessment (IGA) Score at Weeks 2, 4, 8, and 12",
+  "description": "The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12"
+  },
+  {
+  "measure": "Percentage of Participants Who Were Treatment Responders at Week 12",
+  "description": "Treatment responders were defined as participants who have either (1) 2 ordinal or more reductions in the IGA score from baseline or (2) an IGA score of 0 or 1.\n\nThe IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "timeFrame": "Baseline, Week 12"
+  },
+  {
+  "measure": "Change From Baseline in Papule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12"
+  },
+  {
+  "measure": "Change From Baseline in Pustule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12"
+  },
+  {
+  "measure": "Change From Baseline in Nodule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12"
+  },
+  {
+  "measure": "Change From Baseline in Papules + Pustules Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papules + pustules lesions were the sum of counts of papule (raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material) and pustule (raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material) lesions.",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12"
+  },
+  {
+  "measure": "Number of Participants With Adverse Events",
+  "description": "Number of participants reporting any adverse event including local tolerability of signs and symptoms of irritation, clinical laboratory safety tests, and vital signs.",
+  "timeFrame": "Baseline to Week 14"
+  }
+  ],
+  "otherOutcomes": [
+  {
+  "measure": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Week 12",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "timeFrame": "Week 12"
+  },
+  {
+  "measure": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "timeFrame": "Day 1 (Post-application) and Weeks 2, 4, 8, and 14"
+  }
+  ]
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Inclusion Criteria:\n\n* Participant is male or non-pregnant and non-lactating female at least 18 years of age\n* Participant has a clinical diagnosis of stable papulopustular rosacea (type-2)\n* Participant has a total of ≥10 and ≤40 inflammatory lesions (papules, pustules, and nodules) on the face\n* Participant has ≤2 nodules on the face\n* Participant has an investigator's global assessment (IGA) score of ≥3\n* If the participant is a woman of childbearing potential, she has a negative urine pregnancy test and agrees to use an approved effective method of birth control for the duration of the study\n* Participant is in good general health and free of any known disease state or physical condition which, in the investigator's opinion, might impair evaluation of rosacea or which exposes the participant to an unacceptable risk by study participation\n* Participant is willing and able to follow all study instructions and to attend all study visits\n* Participant is able to comprehend and willing to sign an informed consent form\n\nExclusion Criteria:\n\n* Participant is pregnant, nursing, or planning to become pregnant during the duration of the study\n* Participant has used systemic glucocorticosteroids within 42 days prior to Visit 1 (inhaled and ocular glucocorticosteroids are permitted)\n* Participant has used systemic antibiotics within 28 days prior to Visit 1\n* Participant has used any topical glucocorticosteroids on the face within 28 days prior to Visit 1\n* Participant has used any prescription or over-the-counter product for the treatment of acne or rosacea within 14 days prior to Visit 1\n* Participant is currently using any therapy that, in the investigator's opinion, is a photosensitizer (for example, phenothiazines, amiodarone, quinine, thiazides, sulphonamides, quinolones, etc.)\n* Participant currently has any skin disease (for example, psoriasis, atopic dermatitis, eczema), or condition (for example, actinic keratosis, photo-damage, sunburn, excessive hair, open wounds) that, in the investigator's opinion, might impair evaluation of rosacea or which exposes the subject to an unacceptable risk by study participation\n* Participant currently has, on the face, or has had on the face, any of the following within the specified period prior to Visit 1 that, in the investigator's opinion, might impair evaluation of rosacea or which exposes the subject to an unacceptable risk by study participation:\n\n  * A cutaneous malignancy; 180 days\n  * Experienced a sunburn; 14 days\n* Participant has facial hair, that in the investigator's opinion, might impair evaluation of rosacea or proper study medication application\n* Participant has a history of sensitivity to any of the ingredients in the study medications\n* Participant has participated in an investigational drug trial in which administration of an investigational study medication occurred within 30 days prior to Visit 1",
+  "healthyVolunteers": false,
+  "sex": "ALL",
+  "minimumAge": "18 Years",
+  "stdAges": [
+  "ADULT",
+  "OLDER_ADULT"
+  ]
+  },
+  "contactsLocationsModule": {
+  "locations": [
+  {
+  "facility": "DS Research",
+  "city": "Louisville",
+  "state": "Kentucky",
+  "zip": "40421",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 38.25424,
+  "lon": -85.75941
+  }
+  },
+  {
+  "facility": "DermResearch",
+  "city": "Austin",
+  "state": "Texas",
+  "zip": "78759",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 30.26715,
+  "lon": -97.74306
+  }
+  }
+  ]
+  },
+  "referencesModule": {
+  "references": [
+  {
+  "pmid": "34076401",
+  "type": "DERIVED",
+  "citation": "Jackson JM, Coulon R, Arbiser JL. Evaluation of a First-in-Class Proteasome Inhibitor in Patients With Moderate to Severe Rosacea. J Drugs Dermatol. 2021 Jun 1;20(6):660-664. doi: 10.36849/JDD.2021.5925."
+  }
+  ]
+  },
+  "ipdSharingStatementModule": {
+  "ipdSharing": "NO"
+  }
+  },
+  "resultsSection": {
+  "participantFlowModule": {
+  "preAssignmentDetails": "Eligible participants will be assigned in a random manner to 1 of the 2 study medications in a 2:1 ratio (ACU-D1 ointment: ACU-D1 ointment vehicle).",
+  "recruitmentDetails": "The study was conducted at two sites in the United States.",
+  "groups": [
+  {
+  "id": "FG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "FG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "periods": [
+  {
+  "title": "Overall Study",
+  "milestones": [
+  {
+  "type": "STARTED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "27"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "13"
+  }
+  ]
+  },
+  {
+  "type": "COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "26"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "12"
+  }
+  ]
+  },
+  {
+  "type": "NOT COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  }
+  ],
+  "dropWithdraws": [
+  {
+  "type": "Lost to Follow-up",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "0"
+  }
+  ]
+  },
+  {
+  "type": "Withdrawal by Subject",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "0"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "baselineCharacteristicsModule": {
+  "populationDescription": "The modified intention-to-treat (MITT) population included all randomized participants who were dispensed study medication and provided any post-baseline efficacy data.",
+  "groups": [
+  {
+  "id": "BG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "BG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  },
+  {
+  "id": "BG002",
+  "title": "Total",
+  "description": "Total of all reporting groups"
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "27"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "40"
+  }
+  ]
+  }
+  ],
+  "measures": [
+  {
+  "title": "Age, Continuous",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "years",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "49.59",
+  "spread": "11.537"
+  },
+  {
+  "groupId": "BG001",
+  "value": "51.08",
+  "spread": "12.473"
+  },
+  {
+  "groupId": "BG002",
+  "value": "50.08",
+  "spread": "11.708"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Sex: Female, Male",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Female",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "23"
+  },
+  {
+  "groupId": "BG001",
+  "value": "11"
+  },
+  {
+  "groupId": "BG002",
+  "value": "34"
+  }
+  ]
+  },
+  {
+  "title": "Male",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "4"
+  },
+  {
+  "groupId": "BG001",
+  "value": "2"
+  },
+  {
+  "groupId": "BG002",
+  "value": "6"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Ethnicity (NIH/OMB)",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Not Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "22"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "35"
+  }
+  ]
+  },
+  {
+  "title": "Unknown or Not Reported",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Race (NIH/OMB)",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "American Indian or Alaska Native",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Asian",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Native Hawaiian or Other Pacific Islander",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Black or African American",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "White",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "27"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "40"
+  }
+  ]
+  },
+  {
+  "title": "More than one race",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Unknown or Not Reported",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Total lesion count",
+  "description": "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\< 0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\< 0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥ 0.5 cm in diameter.",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "number of lesions",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "18.00",
+  "spread": "9.413"
+  },
+  {
+  "groupId": "BG001",
+  "value": "20.46",
+  "spread": "9.777"
+  },
+  {
+  "groupId": "BG002",
+  "value": "18.80",
+  "spread": "9.479"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Erythema score based on local tolerability as assessed by the investigator",
+  "description": "Erythema score at baseline (pre-application) was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present; Score 1 (mild): slight erythema; Score 2 (moderate): definite erythema; Score 3 (severe): marked, fiery erythema. The assessment was based on the safety population which included all randomized participants who received at least 1 dose of study medication.",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "2"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "4"
+  },
+  {
+  "groupId": "BG002",
+  "value": "9"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "16"
+  },
+  {
+  "groupId": "BG001",
+  "value": "5"
+  },
+  {
+  "groupId": "BG002",
+  "value": "21"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "8"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "outcomeMeasuresModule": {
+  "outcomeMeasures": [
+  {
+  "type": "PRIMARY",
+  "title": "Change From Baseline in Total Lesion Count at Week 12",
+  "description": "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter.",
+  "populationDescription": "Number of participants included participants in the MITT population with available data at Week 12.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline, Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.2",
+  "spread": "1.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-12.0",
+  "spread": "1.62"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.366",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of Least Squares (LS) Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.162",
+  "ciUpperLimit": "5.727",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.95"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percent Change From Baseline in Investigator's Global Assessment (IGA) Score at Weeks 2, 4, 8, and 12",
+  "description": "The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specific timepoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Standard Deviation",
+  "unitOfMeasure": "percent change",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-23",
+  "spread": "0.2561"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-29",
+  "spread": "0.1653"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-35",
+  "spread": "0.2387"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-26",
+  "spread": "0.2771"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-31",
+  "spread": "0.2538"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-29",
+  "spread": "0.2233"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-31",
+  "spread": "0.2588"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-26",
+  "spread": "0.3583"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.1099",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.1653",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.8437",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.4644",
+  "statisticalMethod": "Van Elteren test"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants Who Were Treatment Responders at Week 12",
+  "description": "Treatment responders were defined as participants who have either (1) 2 ordinal or more reductions in the IGA score from baseline or (2) an IGA score of 0 or 1.\n\nThe IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available IGA score at Week 12.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "percentage of participants",
+  "timeFrame": "Baseline, Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "19.2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "18.2"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "1.0",
+  "statisticalMethod": "Fisher Exact"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Papule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-6.6",
+  "spread": "1.09"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-7.95",
+  "spread": "1.57"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.7",
+  "spread": "0.97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-8.22",
+  "spread": "1.44"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-8.1",
+  "spread": "1.16"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-10.30",
+  "spread": "1.71"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.2",
+  "spread": "1.01"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-10.98",
+  "spread": "1.53"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.495",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.3",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.571",
+  "ciUpperLimit": "5.211",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.91"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.399",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-1.5",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-5.014",
+  "ciUpperLimit": "2.045",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.74"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.290",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.2",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.965",
+  "ciUpperLimit": "6.407",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.343",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.953",
+  "ciUpperLimit": "5.469",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.83"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Pustule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.4",
+  "spread": "0.43"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.98",
+  "spread": "0.62"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.2",
+  "spread": "0.20"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.63",
+  "spread": "0.30"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.1",
+  "spread": "0.25"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.29",
+  "spread": "0.38"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.0",
+  "spread": "0.31"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.04",
+  "spread": "0.48"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.407",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.6",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.894",
+  "ciUpperLimit": "2.155",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.75"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.291",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.4",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.342",
+  "ciUpperLimit": "1.109",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.36"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.734",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.2",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.763",
+  "ciUpperLimit": "1.073",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.45"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline in pustule lesions at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.952",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.128",
+  "ciUpperLimit": "1.197",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.57"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Nodule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0.02",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.05",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.05",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0.04",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.313",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-0.1",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.215",
+  "ciUpperLimit": "0.069",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.942",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.141",
+  "ciUpperLimit": "0.152",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline in nodule lesions at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.284",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.1",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.067",
+  "ciUpperLimit": "0.226",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.542",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.198",
+  "ciUpperLimit": "0.105",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.08"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Papules + Pustules Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papules + pustules lesions were the sum of counts of papule (raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material) and pustule (raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material) lesions.",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-7.0",
+  "spread": "1.16"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-8.97",
+  "spread": "1.67"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.9",
+  "spread": "1.06"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-9.90",
+  "spread": "1.57"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.2",
+  "spread": "1.19"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-11.65",
+  "spread": "1.75"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.2",
+  "spread": "1.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-12.03",
+  "spread": "1.62"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.333",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.135",
+  "ciUpperLimit": "6.139",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.04"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.591",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-1.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-4.882",
+  "ciUpperLimit": "2.822",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.90"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.254",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.5",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.840",
+  "ciUpperLimit": "6.758",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.12"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.356",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.131",
+  "ciUpperLimit": "5.779",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.95"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Number of Participants With Adverse Events",
+  "description": "Number of participants reporting any adverse event including local tolerability of signs and symptoms of irritation, clinical laboratory safety tests, and vital signs.",
+  "populationDescription": "Safety population included all randomized participants who received at least 1 dose of study medication.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Baseline to Week 14",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "11"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "OTHER_PRE_SPECIFIED",
+  "title": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Week 12",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "populationDescription": "Safety population included all randomized participants who received at least 1 dose of study medication. Number of participants analyzed included participants with available data at specified timepoints.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "14"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "9"
+  },
+  {
+  "groupId": "OG001",
+  "value": "6"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "OTHER_PRE_SPECIFIED",
+  "title": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "populationDescription": "Safety population. Number of participants analyzed included participants with available data at specified timepoints.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Day 1 (Post-application)",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "9"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "5"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "7"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "2"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "7"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "11"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "6"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 14",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "8"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "adverseEventsModule": {
+  "frequencyThreshold": "0",
+  "timeFrame": "Baseline up to Week 14",
+  "description": "Safety population",
+  "eventGroups": [
+  {
+  "id": "EG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 27,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 27,
+  "otherNumAffected": 11,
+  "otherNumAtRisk": 27
+  },
+  {
+  "id": "EG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 13,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 13,
+  "otherNumAffected": 4,
+  "otherNumAtRisk": 13
+  }
+  ],
+  "otherEvents": [
+  {
+  "term": "Vomiting",
+  "organSystem": "Gastrointestinal disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Administration site dryness",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Administration site warmth",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Application site perspiration",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Ear infection",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Nasopharyngitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 2,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 2,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Respiratory tract infection",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Sinusitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Tibia fracture",
+  "organSystem": "Injury, poisoning and procedural complications",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "White blood cell count decreased",
+  "organSystem": "Investigations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Vitamin D deficiency",
+  "organSystem": "Metabolism and nutrition disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Cough",
+  "organSystem": "Respiratory, thoracic and mediastinal disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  }
+  ]
+  },
+  "moreInfoModule": {
+  "certainAgreement": {
+  "piSponsorEmployee": false,
+  "restrictiveAgreement": false
+  },
+  "pointOfContact": {
+  "title": "Chief Science Officer",
+  "organization": "Accuitis, Inc.",
+  "email": "info@accuitis.com",
+  "phone": "678-812-1492"
+  }
+  }
+  },
+  "documentSection": {
+  "largeDocumentModule": {
+  "largeDocs": [
+  {
+  "typeAbbrev": "Prot",
+  "hasProtocol": true,
+  "hasSap": false,
+  "hasIcf": false,
+  "label": "Study Protocol",
+  "date": "2017-08-05",
+  "uploadDate": "2021-08-13T11:54",
+  "filename": "Prot_000.pdf",
+  "size": 642802
+  },
+  {
+  "typeAbbrev": "SAP",
+  "hasProtocol": false,
+  "hasSap": true,
+  "hasIcf": false,
+  "label": "Statistical Analysis Plan",
+  "date": "2018-05-11",
+  "uploadDate": "2021-08-13T11:56",
+  "filename": "SAP_001.pdf",
+  "size": 7296067
+  }
+  ]
+  }
+  },
+  "annotationSection": {
+  "annotationModule": {
+  "violationAnnotation": {
+  "violationEvents": [
+  {
+  "type": "CORRECTION_CONFIRMED",
+  "description": "The responsible party has corrected the violation.",
+  "creationDate": "2022-06-06",
+  "issuedDate": "2022-05-26",
+  "releaseDate": "2021-08-17",
+  "postedDate": "2022-06-07"
+  },
+  {
+  "type": "VIOLATION_IDENTIFIED",
+  "description": "Failure to Submit. The entry for this clinical trial was not complete at the time of submission, as required by law. This may or may not have any bearing on the accuracy of the information in the entry.",
+  "creationDate": "2021-07-28",
+  "issuedDate": "2021-07-26",
+  "releaseDate": "2018-04-12",
+  "postedDate": "2021-07-29"
+  }
+  ]
+  }
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2024-01-03",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000012393",
+  "term": "Rosacea"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000012871",
+  "term": "Skin Diseases"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M3202",
+  "name": "Acne Vulgaris",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M14904",
+  "name": "Rosacea",
+  "asFound": "Rosacea",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M15364",
+  "name": "Skin Diseases",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BC17",
+  "name": "Skin and Connective Tissue Diseases"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  }
+  ]
+  }
+  },
+  "hasResults": true
+  }

--- a/spec/support/json_data/design_outcome_empty.json
+++ b/spec/support/json_data/design_outcome_empty.json
@@ -1,0 +1,2978 @@
+{
+  "protocolSection": {
+  "identificationModule": {
+  "nctId": "NCT01234567",
+  "orgStudyIdInfo": {
+  "id": "ACU-D1"
+  },
+  "organization": {
+  "fullName": "Accuitis, Inc.",
+  "class": "INDUSTRY"
+  },
+  "briefTitle": "Safety and Efficacy of ACU-D1 in the Treatment of Acne Rosacea",
+  "officialTitle": "A RANDOMIZED, DOUBLE-BLIND, VEHICLE CONTROLLED, PROOF-OF CONCEPT STUDY OF THE SAFETY AND EFFICACY OF ACU-D1 OINTMENT IN SUBJECTS WITH ACNE ROSACEA"
+  },
+  "statusModule": {
+  "statusVerifiedDate": "2021-08",
+  "overallStatus": "COMPLETED",
+  "expandedAccessInfo": {
+  "hasExpandedAccess": false
+  },
+  "startDateStruct": {
+  "date": "2017-11-28",
+  "type": "ACTUAL"
+  },
+  "primaryCompletionDateStruct": {
+  "date": "2018-06-05",
+  "type": "ACTUAL"
+  },
+  "completionDateStruct": {
+  "date": "2018-06-18",
+  "type": "ACTUAL"
+  },
+  "studyFirstSubmitDate": "2017-02-22",
+  "studyFirstSubmitQcDate": "2017-02-24",
+  "studyFirstPostDateStruct": {
+  "date": "2017-02-27",
+  "type": "ACTUAL"
+  },
+  "resultsFirstSubmitDate": "2021-08-17",
+  "resultsFirstSubmitQcDate": "2021-08-17",
+  "resultsFirstPostDateStruct": {
+  "date": "2021-08-23",
+  "type": "ACTUAL"
+  },
+  "lastUpdateSubmitDate": "2021-08-17",
+  "lastUpdatePostDateStruct": {
+  "date": "2021-08-23",
+  "type": "ACTUAL"
+  }
+  },
+  "sponsorCollaboratorsModule": {
+  "responsibleParty": {
+  "type": "SPONSOR"
+  },
+  "leadSponsor": {
+  "name": "Accuitis, Inc.",
+  "class": "INDUSTRY"
+  }
+  },
+  "oversightModule": {
+  "oversightHasDmc": false,
+  "isFdaRegulatedDrug": true,
+  "isFdaRegulatedDevice": false,
+  "isUsExport": false,
+  "fdaaa801Violation": true
+  },
+  "descriptionModule": {
+  "briefSummary": "The study evaluated the safety, tolerability, and efficacy of ACCU-D1 when applied twice daily for 12 weeks in adult participants with moderate to severe acne rosacea. Two-third of the participants received ACCU-D1 while one-third of the participants received vehicle control."
+  },
+  "conditionsModule": {
+  "conditions": [
+  "Acne Rosacea"
+  ]
+  },
+  "designModule": {
+  "studyType": "INTERVENTIONAL",
+  "phases": [
+  "PHASE2"
+  ],
+  "designInfo": {
+  "allocation": "RANDOMIZED",
+  "interventionModel": "PARALLEL",
+  "primaryPurpose": "TREATMENT",
+  "maskingInfo": {
+  "masking": "DOUBLE",
+  "whoMasked": [
+  "PARTICIPANT",
+  "INVESTIGATOR"
+  ]
+  }
+  },
+  "enrollmentInfo": {
+  "count": 40,
+  "type": "ACTUAL"
+  }
+  },
+  "armsInterventionsModule": {
+  "armGroups": [
+  {
+  "label": "ACU-D1 Ointment",
+  "type": "EXPERIMENTAL",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks.",
+  "interventionNames": [
+  "Drug: ACCU-D1"
+  ]
+  },
+  {
+  "label": "ACU-D1 Ointment Vehicle",
+  "type": "PLACEBO_COMPARATOR",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks.",
+  "interventionNames": [
+  "Drug: Vehicle"
+  ]
+  }
+  ],
+  "interventions": [
+  {
+  "type": "DRUG",
+  "name": "ACCU-D1",
+  "description": "ACCU-D1",
+  "armGroupLabels": [
+  "ACU-D1 Ointment"
+  ]
+  },
+  {
+  "type": "DRUG",
+  "name": "Vehicle",
+  "description": "Placebo Comparator",
+  "armGroupLabels": [
+  "ACU-D1 Ointment Vehicle"
+  ]
+  }
+  ]
+  },
+  "outcomesModule": {
+  },
+  "eligibilityModule": {
+  "eligibilityCriteria": "Inclusion Criteria:\n\n* Participant is male or non-pregnant and non-lactating female at least 18 years of age\n* Participant has a clinical diagnosis of stable papulopustular rosacea (type-2)\n* Participant has a total of ≥10 and ≤40 inflammatory lesions (papules, pustules, and nodules) on the face\n* Participant has ≤2 nodules on the face\n* Participant has an investigator's global assessment (IGA) score of ≥3\n* If the participant is a woman of childbearing potential, she has a negative urine pregnancy test and agrees to use an approved effective method of birth control for the duration of the study\n* Participant is in good general health and free of any known disease state or physical condition which, in the investigator's opinion, might impair evaluation of rosacea or which exposes the participant to an unacceptable risk by study participation\n* Participant is willing and able to follow all study instructions and to attend all study visits\n* Participant is able to comprehend and willing to sign an informed consent form\n\nExclusion Criteria:\n\n* Participant is pregnant, nursing, or planning to become pregnant during the duration of the study\n* Participant has used systemic glucocorticosteroids within 42 days prior to Visit 1 (inhaled and ocular glucocorticosteroids are permitted)\n* Participant has used systemic antibiotics within 28 days prior to Visit 1\n* Participant has used any topical glucocorticosteroids on the face within 28 days prior to Visit 1\n* Participant has used any prescription or over-the-counter product for the treatment of acne or rosacea within 14 days prior to Visit 1\n* Participant is currently using any therapy that, in the investigator's opinion, is a photosensitizer (for example, phenothiazines, amiodarone, quinine, thiazides, sulphonamides, quinolones, etc.)\n* Participant currently has any skin disease (for example, psoriasis, atopic dermatitis, eczema), or condition (for example, actinic keratosis, photo-damage, sunburn, excessive hair, open wounds) that, in the investigator's opinion, might impair evaluation of rosacea or which exposes the subject to an unacceptable risk by study participation\n* Participant currently has, on the face, or has had on the face, any of the following within the specified period prior to Visit 1 that, in the investigator's opinion, might impair evaluation of rosacea or which exposes the subject to an unacceptable risk by study participation:\n\n  * A cutaneous malignancy; 180 days\n  * Experienced a sunburn; 14 days\n* Participant has facial hair, that in the investigator's opinion, might impair evaluation of rosacea or proper study medication application\n* Participant has a history of sensitivity to any of the ingredients in the study medications\n* Participant has participated in an investigational drug trial in which administration of an investigational study medication occurred within 30 days prior to Visit 1",
+  "healthyVolunteers": false,
+  "sex": "ALL",
+  "minimumAge": "18 Years",
+  "stdAges": [
+  "ADULT",
+  "OLDER_ADULT"
+  ]
+  },
+  "contactsLocationsModule": {
+  "locations": [
+  {
+  "facility": "DS Research",
+  "city": "Louisville",
+  "state": "Kentucky",
+  "zip": "40421",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 38.25424,
+  "lon": -85.75941
+  }
+  },
+  {
+  "facility": "DermResearch",
+  "city": "Austin",
+  "state": "Texas",
+  "zip": "78759",
+  "country": "United States",
+  "geoPoint": {
+  "lat": 30.26715,
+  "lon": -97.74306
+  }
+  }
+  ]
+  },
+  "referencesModule": {
+  "references": [
+  {
+  "pmid": "34076401",
+  "type": "DERIVED",
+  "citation": "Jackson JM, Coulon R, Arbiser JL. Evaluation of a First-in-Class Proteasome Inhibitor in Patients With Moderate to Severe Rosacea. J Drugs Dermatol. 2021 Jun 1;20(6):660-664. doi: 10.36849/JDD.2021.5925."
+  }
+  ]
+  },
+  "ipdSharingStatementModule": {
+  "ipdSharing": "NO"
+  }
+  },
+  "resultsSection": {
+  "participantFlowModule": {
+  "preAssignmentDetails": "Eligible participants will be assigned in a random manner to 1 of the 2 study medications in a 2:1 ratio (ACU-D1 ointment: ACU-D1 ointment vehicle).",
+  "recruitmentDetails": "The study was conducted at two sites in the United States.",
+  "groups": [
+  {
+  "id": "FG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "FG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "periods": [
+  {
+  "title": "Overall Study",
+  "milestones": [
+  {
+  "type": "STARTED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "27"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "13"
+  }
+  ]
+  },
+  {
+  "type": "COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "26"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "12"
+  }
+  ]
+  },
+  {
+  "type": "NOT COMPLETED",
+  "achievements": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  }
+  ],
+  "dropWithdraws": [
+  {
+  "type": "Lost to Follow-up",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "1"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "0"
+  }
+  ]
+  },
+  {
+  "type": "Withdrawal by Subject",
+  "reasons": [
+  {
+  "groupId": "FG000",
+  "numSubjects": "0"
+  },
+  {
+  "groupId": "FG001",
+  "numSubjects": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "baselineCharacteristicsModule": {
+  "populationDescription": "The modified intention-to-treat (MITT) population included all randomized participants who were dispensed study medication and provided any post-baseline efficacy data.",
+  "groups": [
+  {
+  "id": "BG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "BG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  },
+  {
+  "id": "BG002",
+  "title": "Total",
+  "description": "Total of all reporting groups"
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "BG000",
+  "value": "27"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "40"
+  }
+  ]
+  }
+  ],
+  "measures": [
+  {
+  "title": "Age, Continuous",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "years",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "49.59",
+  "spread": "11.537"
+  },
+  {
+  "groupId": "BG001",
+  "value": "51.08",
+  "spread": "12.473"
+  },
+  {
+  "groupId": "BG002",
+  "value": "50.08",
+  "spread": "11.708"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Sex: Female, Male",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Female",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "23"
+  },
+  {
+  "groupId": "BG001",
+  "value": "11"
+  },
+  {
+  "groupId": "BG002",
+  "value": "34"
+  }
+  ]
+  },
+  {
+  "title": "Male",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "4"
+  },
+  {
+  "groupId": "BG001",
+  "value": "2"
+  },
+  {
+  "groupId": "BG002",
+  "value": "6"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Ethnicity (NIH/OMB)",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Not Hispanic or Latino",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "22"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "35"
+  }
+  ]
+  },
+  {
+  "title": "Unknown or Not Reported",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Race (NIH/OMB)",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "American Indian or Alaska Native",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Asian",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Native Hawaiian or Other Pacific Islander",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Black or African American",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "White",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "27"
+  },
+  {
+  "groupId": "BG001",
+  "value": "13"
+  },
+  {
+  "groupId": "BG002",
+  "value": "40"
+  }
+  ]
+  },
+  {
+  "title": "More than one race",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Unknown or Not Reported",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "0"
+  },
+  {
+  "groupId": "BG001",
+  "value": "0"
+  },
+  {
+  "groupId": "BG002",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Total lesion count",
+  "description": "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\< 0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\< 0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥ 0.5 cm in diameter.",
+  "paramType": "MEAN",
+  "dispersionType": "STANDARD_DEVIATION",
+  "unitOfMeasure": "number of lesions",
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "18.00",
+  "spread": "9.413"
+  },
+  {
+  "groupId": "BG001",
+  "value": "20.46",
+  "spread": "9.777"
+  },
+  {
+  "groupId": "BG002",
+  "value": "18.80",
+  "spread": "9.479"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Erythema score based on local tolerability as assessed by the investigator",
+  "description": "Erythema score at baseline (pre-application) was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present; Score 1 (mild): slight erythema; Score 2 (moderate): definite erythema; Score 3 (severe): marked, fiery erythema. The assessment was based on the safety population which included all randomized participants who received at least 1 dose of study medication.",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "1"
+  },
+  {
+  "groupId": "BG001",
+  "value": "1"
+  },
+  {
+  "groupId": "BG002",
+  "value": "2"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "4"
+  },
+  {
+  "groupId": "BG002",
+  "value": "9"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "16"
+  },
+  {
+  "groupId": "BG001",
+  "value": "5"
+  },
+  {
+  "groupId": "BG002",
+  "value": "21"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "BG000",
+  "value": "5"
+  },
+  {
+  "groupId": "BG001",
+  "value": "3"
+  },
+  {
+  "groupId": "BG002",
+  "value": "8"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "outcomeMeasuresModule": {
+  "outcomeMeasures": [
+  {
+  "type": "PRIMARY",
+  "title": "Change From Baseline in Total Lesion Count at Week 12",
+  "description": "Total lesion count was the sum of counts of the following lesion types (face only): Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material; Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material; Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter.",
+  "populationDescription": "Number of participants included participants in the MITT population with available data at Week 12.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline, Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.2",
+  "spread": "1.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-12.0",
+  "spread": "1.62"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.366",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of Least Squares (LS) Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.162",
+  "ciUpperLimit": "5.727",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.95"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percent Change From Baseline in Investigator's Global Assessment (IGA) Score at Weeks 2, 4, 8, and 12",
+  "description": "The IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specific timepoint.",
+  "reportingStatus": "POSTED",
+  "paramType": "MEAN",
+  "dispersionType": "Standard Deviation",
+  "unitOfMeasure": "percent change",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-23",
+  "spread": "0.2561"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-29",
+  "spread": "0.1653"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-35",
+  "spread": "0.2387"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-26",
+  "spread": "0.2771"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-31",
+  "spread": "0.2538"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-29",
+  "spread": "0.2233"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-31",
+  "spread": "0.2588"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-26",
+  "spread": "0.3583"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.1099",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.1653",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.8437",
+  "statisticalMethod": "Van Elteren test"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Percent change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.4644",
+  "statisticalMethod": "Van Elteren test"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Percentage of Participants Who Were Treatment Responders at Week 12",
+  "description": "Treatment responders were defined as participants who have either (1) 2 ordinal or more reductions in the IGA score from baseline or (2) an IGA score of 0 or 1.\n\nThe IGA score is an ordered categorical value ranging from 0 (clear) to 4 (severe). A lower score indicated improvement in the condition.\n\nScore 0 (clear): no papules or pustules, no nodules, none or barely perceptible erythema\n\nScore 1 (near clear): very few (≤3) papules and/or pustules, no nodules, very mild erythema\n\nScore 2 (mild): few papules and pustules present, no nodules, mild erythema\n\nScore 3 (moderate): several papules and pustules are the predominant features, ≤2 nodules may be present, moderate erythema\n\nScore 4 (severe): numerous papules and pustules, multiple nodules may be present, severe erythema",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available IGA score at Week 12.",
+  "reportingStatus": "POSTED",
+  "paramType": "NUMBER",
+  "unitOfMeasure": "percentage of participants",
+  "timeFrame": "Baseline, Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "19.2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "18.2"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "1.0",
+  "statisticalMethod": "Fisher Exact"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Papule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papule - raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-6.6",
+  "spread": "1.09"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-7.95",
+  "spread": "1.57"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.7",
+  "spread": "0.97"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-8.22",
+  "spread": "1.44"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-8.1",
+  "spread": "1.16"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-10.30",
+  "spread": "1.71"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.2",
+  "spread": "1.01"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-10.98",
+  "spread": "1.53"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.495",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.3",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.571",
+  "ciUpperLimit": "5.211",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.91"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.399",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-1.5",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-5.014",
+  "ciUpperLimit": "2.045",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.74"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.290",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.2",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.965",
+  "ciUpperLimit": "6.407",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.343",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.953",
+  "ciUpperLimit": "5.469",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.83"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Pustule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Pustule - raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-0.4",
+  "spread": "0.43"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.98",
+  "spread": "0.62"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.2",
+  "spread": "0.20"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.63",
+  "spread": "0.30"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.1",
+  "spread": "0.25"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.29",
+  "spread": "0.38"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-1.0",
+  "spread": "0.31"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-1.04",
+  "spread": "0.48"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.407",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.6",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.894",
+  "ciUpperLimit": "2.155",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.75"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.291",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.4",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.342",
+  "ciUpperLimit": "1.109",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.36"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.734",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.2",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.763",
+  "ciUpperLimit": "1.073",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.45"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline in pustule lesions at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.952",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.128",
+  "ciUpperLimit": "1.197",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.57"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Nodule Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Nodule - any circumscribed, inflammatory mass ≥0.5 cm in diameter",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0.02",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.05",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-0.05",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0.0",
+  "spread": "0.04"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0.04",
+  "spread": "0.06"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.313",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-0.1",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.215",
+  "ciUpperLimit": "0.069",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.942",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.141",
+  "ciUpperLimit": "0.152",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline in nodule lesions at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.284",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.1",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.067",
+  "ciUpperLimit": "0.226",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.07"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.542",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "0.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-0.198",
+  "ciUpperLimit": "0.105",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "0.08"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Change From Baseline in Papules + Pustules Lesions at Weeks 2, 4, 8, and 12",
+  "description": "Papules + pustules lesions were the sum of counts of papule (raised inflammatory lesions, \\<0.5 cm in diameter with no visible purulent material) and pustule (raised inflammatory lesions, \\<0.5 cm in diameter with visible purulent material) lesions.",
+  "populationDescription": "MITT population. Number of participants analyzed included participants with available data at specified visits.",
+  "reportingStatus": "POSTED",
+  "paramType": "LEAST_SQUARES_MEAN",
+  "dispersionType": "Standard Error",
+  "unitOfMeasure": "number of lesions",
+  "timeFrame": "Baseline; Weeks 2, 4, 8, and 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-7.0",
+  "spread": "1.16"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-8.97",
+  "spread": "1.67"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.9",
+  "spread": "1.06"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-9.90",
+  "spread": "1.57"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-9.2",
+  "spread": "1.19"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-11.65",
+  "spread": "1.75"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 12",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "-10.2",
+  "spread": "1.08"
+  },
+  {
+  "groupId": "OG001",
+  "value": "-12.03",
+  "spread": "1.62"
+  }
+  ]
+  }
+  ]
+  }
+  ],
+  "analyses": [
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 2",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.333",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.135",
+  "ciUpperLimit": "6.139",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.04"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 4",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.591",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "-1.0",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-4.882",
+  "ciUpperLimit": "2.822",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.90"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 8",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.254",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "2.5",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-1.840",
+  "ciUpperLimit": "6.758",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "2.12"
+  },
+  {
+  "groupIds": [
+  "OG000",
+  "OG001"
+  ],
+  "groupDescription": "Change from baseline at Week 12",
+  "nonInferiorityType": "SUPERIORITY",
+  "pValue": "0.356",
+  "statisticalMethod": "t-test, 2 sided",
+  "paramType": "Difference of LS Mean",
+  "paramValue": "1.8",
+  "ciPctValue": "95",
+  "ciNumSides": "TWO_SIDED",
+  "ciLowerLimit": "-2.131",
+  "ciUpperLimit": "5.779",
+  "dispersionType": "STANDARD_ERROR_OF_MEAN",
+  "dispersionValue": "1.95"
+  }
+  ]
+  },
+  {
+  "type": "SECONDARY",
+  "title": "Number of Participants With Adverse Events",
+  "description": "Number of participants reporting any adverse event including local tolerability of signs and symptoms of irritation, clinical laboratory safety tests, and vital signs.",
+  "populationDescription": "Safety population included all randomized participants who received at least 1 dose of study medication.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Baseline to Week 14",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "11"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "OTHER_PRE_SPECIFIED",
+  "title": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Week 12",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "populationDescription": "Safety population included all randomized participants who received at least 1 dose of study medication. Number of participants analyzed included participants with available data at specified timepoints.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Week 12",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "11"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "14"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "9"
+  },
+  {
+  "groupId": "OG001",
+  "value": "6"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "type": "OTHER_PRE_SPECIFIED",
+  "title": "Number of Participants With Erythema Score Based on Local Tolerability as Assessed by the Investigator at Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+  "description": "Erythema score was evaluated by the investigator on a 0 to 3 scale with a lower score indicating lesser severity.\n\nScore 0 (clear): no erythema present\n\nScore 1 (mild): slight erythema\n\nScore 2 (moderate): definite erythema\n\nScore 3 (severe): marked, fiery erythema",
+  "populationDescription": "Safety population. Number of participants analyzed included participants with available data at specified timepoints.",
+  "reportingStatus": "POSTED",
+  "paramType": "COUNT_OF_PARTICIPANTS",
+  "unitOfMeasure": "Participants",
+  "timeFrame": "Day 1 (Post-application) and Weeks 2, 4, 8, and 14",
+  "groups": [
+  {
+  "id": "OG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks."
+  },
+  {
+  "id": "OG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks."
+  }
+  ],
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "classes": [
+  {
+  "title": "Day 1 (Post-application)",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "9"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "5"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 2",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "13"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "7"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "2"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 4",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "0"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "4"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "12"
+  },
+  {
+  "groupId": "OG001",
+  "value": "7"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 8",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "27"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "1"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "11"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "6"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "0"
+  }
+  ]
+  }
+  ]
+  },
+  {
+  "title": "Week 14",
+  "denoms": [
+  {
+  "units": "Participants",
+  "counts": [
+  {
+  "groupId": "OG000",
+  "value": "26"
+  },
+  {
+  "groupId": "OG001",
+  "value": "12"
+  }
+  ]
+  }
+  ],
+  "categories": [
+  {
+  "title": "Score 0 (clear)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "2"
+  },
+  {
+  "groupId": "OG001",
+  "value": "1"
+  }
+  ]
+  },
+  {
+  "title": "Score 1 (mild)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "8"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  },
+  {
+  "title": "Score 2 (moderate)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "13"
+  },
+  {
+  "groupId": "OG001",
+  "value": "5"
+  }
+  ]
+  },
+  {
+  "title": "Score 3 (severe)",
+  "measurements": [
+  {
+  "groupId": "OG000",
+  "value": "3"
+  },
+  {
+  "groupId": "OG001",
+  "value": "3"
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  }
+  ]
+  },
+  "adverseEventsModule": {
+  "frequencyThreshold": "0",
+  "timeFrame": "Baseline up to Week 14",
+  "description": "Safety population",
+  "eventGroups": [
+  {
+  "id": "EG000",
+  "title": "ACU-D1 Ointment",
+  "description": "Twice-daily application of ACU-D1 ointment to the face for 12 weeks.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 27,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 27,
+  "otherNumAffected": 11,
+  "otherNumAtRisk": 27
+  },
+  {
+  "id": "EG001",
+  "title": "ACU-D1 Ointment Vehicle",
+  "description": "Twice-daily application of ACU-D1 ointment vehicle to the face for 12 weeks.",
+  "deathsNumAffected": 0,
+  "deathsNumAtRisk": 13,
+  "seriousNumAffected": 0,
+  "seriousNumAtRisk": 13,
+  "otherNumAffected": 4,
+  "otherNumAtRisk": 13
+  }
+  ],
+  "otherEvents": [
+  {
+  "term": "Vomiting",
+  "organSystem": "Gastrointestinal disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Administration site dryness",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Administration site warmth",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Application site perspiration",
+  "organSystem": "General disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Ear infection",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Nasopharyngitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 2,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 2,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Respiratory tract infection",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Sinusitis",
+  "organSystem": "Infections and infestations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Tibia fracture",
+  "organSystem": "Injury, poisoning and procedural complications",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "White blood cell count decreased",
+  "organSystem": "Investigations",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Vitamin D deficiency",
+  "organSystem": "Metabolism and nutrition disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 1,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 0,
+  "numAtRisk": 13
+  }
+  ]
+  },
+  {
+  "term": "Cough",
+  "organSystem": "Respiratory, thoracic and mediastinal disorders",
+  "sourceVocabulary": "MedDRA (21.0)",
+  "assessmentType": "SYSTEMATIC_ASSESSMENT",
+  "stats": [
+  {
+  "groupId": "EG000",
+  "numAffected": 0,
+  "numAtRisk": 27
+  },
+  {
+  "groupId": "EG001",
+  "numAffected": 1,
+  "numAtRisk": 13
+  }
+  ]
+  }
+  ]
+  },
+  "moreInfoModule": {
+  "certainAgreement": {
+  "piSponsorEmployee": false,
+  "restrictiveAgreement": false
+  },
+  "pointOfContact": {
+  "title": "Chief Science Officer",
+  "organization": "Accuitis, Inc.",
+  "email": "info@accuitis.com",
+  "phone": "678-812-1492"
+  }
+  }
+  },
+  "documentSection": {
+  "largeDocumentModule": {
+  "largeDocs": [
+  {
+  "typeAbbrev": "Prot",
+  "hasProtocol": true,
+  "hasSap": false,
+  "hasIcf": false,
+  "label": "Study Protocol",
+  "date": "2017-08-05",
+  "uploadDate": "2021-08-13T11:54",
+  "filename": "Prot_000.pdf",
+  "size": 642802
+  },
+  {
+  "typeAbbrev": "SAP",
+  "hasProtocol": false,
+  "hasSap": true,
+  "hasIcf": false,
+  "label": "Statistical Analysis Plan",
+  "date": "2018-05-11",
+  "uploadDate": "2021-08-13T11:56",
+  "filename": "SAP_001.pdf",
+  "size": 7296067
+  }
+  ]
+  }
+  },
+  "annotationSection": {
+  "annotationModule": {
+  "violationAnnotation": {
+  "violationEvents": [
+  {
+  "type": "CORRECTION_CONFIRMED",
+  "description": "The responsible party has corrected the violation.",
+  "creationDate": "2022-06-06",
+  "issuedDate": "2022-05-26",
+  "releaseDate": "2021-08-17",
+  "postedDate": "2022-06-07"
+  },
+  {
+  "type": "VIOLATION_IDENTIFIED",
+  "description": "Failure to Submit. The entry for this clinical trial was not complete at the time of submission, as required by law. This may or may not have any bearing on the accuracy of the information in the entry.",
+  "creationDate": "2021-07-28",
+  "issuedDate": "2021-07-26",
+  "releaseDate": "2018-04-12",
+  "postedDate": "2021-07-29"
+  }
+  ]
+  }
+  }
+  },
+  "derivedSection": {
+  "miscInfoModule": {
+  "versionHolder": "2024-01-03",
+  "modelPredictions": {
+  "bmiLimits": {
+  "minBmi": 0,
+  "maxBmi": 101
+  }
+  }
+  },
+  "conditionBrowseModule": {
+  "meshes": [
+  {
+  "id": "D000012393",
+  "term": "Rosacea"
+  }
+  ],
+  "ancestors": [
+  {
+  "id": "D000012871",
+  "term": "Skin Diseases"
+  }
+  ],
+  "browseLeaves": [
+  {
+  "id": "M3202",
+  "name": "Acne Vulgaris",
+  "relevance": "LOW"
+  },
+  {
+  "id": "M14904",
+  "name": "Rosacea",
+  "asFound": "Rosacea",
+  "relevance": "HIGH"
+  },
+  {
+  "id": "M15364",
+  "name": "Skin Diseases",
+  "relevance": "LOW"
+  }
+  ],
+  "browseBranches": [
+  {
+  "abbrev": "BC17",
+  "name": "Skin and Connective Tissue Diseases"
+  },
+  {
+  "abbrev": "All",
+  "name": "All Conditions"
+  }
+  ]
+  }
+  },
+  "hasResults": true
+  }


### PR DESCRIPTION
- Removed design_outcomes_data method from ProcessorV2 class
- Created mapper method in DesignOutcome class
- Removed xml mapping and attribs method
- Added RSpec test cases in design_outcome_spec.rb file
- All Test Cases PASS:

<img width="980" alt="Screen Shot 2024-01-22 at 9 40 51 PM" src="https://github.com/ctti-clinicaltrials/aact/assets/81119399/8deda1d1-0134-40ad-86f8-629fbdd6153d">
