### PR TITLE
Fix - Add Indexes to Public Database

### DIFF
--- a/app/models/util/updater_v2.rb
+++ b/app/models/util/updater_v2.rb
@@ -30,10 +30,10 @@ module Util
       create_load_event
       log("🚀🚀🚀 Execute Event for #{@schema} schema 🚀🚀🚀", false, true)
 
-      run_step("Remove Contraints") { db_mgr.remove_constraints }
+      run_step("Remove Indexes/Contraints") { db_mgr.remove_indexes_and_constraints }
       run_step("Download Studies") { StudyDownloader.download_recently_updated}
       run_step("Process Studies") { worker.import_all}
-      run_step("Add Constraints") { db_mgr.add_constraints }
+      run_step("Add Indexes/Constraints") { db_mgr.add_indexes_and_constraints }
       run_step("Compare Counts", skipped = true)
       run_step("Study Searches", skipped = true)
       run_step("Sanity Checks") { @load_event.run_sanity_checks(@schema) }


### PR DESCRIPTION
This PR fixes slow queries issues running against public database by adding indexes to the backend database before its snapshot restored to the public database.

Tested by running "slow" query provided by the user in the local version of public db (limited number of studies):

**without** indexes:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/9be4a8eb-9a63-410c-8193-9d6d66913a22">

**with** indexes:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/11044c85-e697-4154-a1d8-83769787eac7">
